### PR TITLE
Enable buildinstaller.sh on Raspberry Pi

### DIFF
--- a/buildinstaller.sh
+++ b/buildinstaller.sh
@@ -38,6 +38,9 @@ case "$system" in
 			x86_64|amd64|x64)
 				machine="x64"
 				;;
+			armv6l)
+				machine="arm"
+				;;
 			*)
 				echo "Unsupported machine type: $machine"
 				exit 2


### PR DESCRIPTION
So that you can build a redistributable install for Pi, with nice things
like init scripts etc.

@adamierymenko do you have any plans for a Raspberry Pi binary release?         

Not sure how your automated packaging works ATM but I'd be happy to  
help for Pi. Alternatively I could just build "unofficial" binary  
installers.       
