### PR TITLE
Fixed member authorization bug and minor cleanup

### DIFF
--- a/controller/SqliteNetworkController.hpp
+++ b/controller/SqliteNetworkController.hpp
@@ -122,6 +122,8 @@ private:
 	sqlite3_stmt *_sDeleteIpAssignmentPoolsForNetwork;
 	sqlite3_stmt *_sDeleteRulesForNetwork;
 	sqlite3_stmt *_sCreateIpAssignmentPool;
+	sqlite3_stmt *_sUpdateMemberAuthorized;
+	sqlite3_stmt *_sUpdateMemberActiveBridge;
 	sqlite3_stmt *_sDeleteMember;
 	sqlite3_stmt *_sDeleteNetwork;
 	sqlite3_stmt *_sGetGateways;


### PR DESCRIPTION
A private network was automatically authorized. Fixed that.
See: *sqlite3_bind_int(_sCreateMember,3,(member.authorized ? 1 : 0))*

Also moved two update statements to the section with other prepared statements.