### PR TITLE
Fix signing verification

### DIFF
--- a/controller/SqliteNetworkController.cpp
+++ b/controller/SqliteNetworkController.cpp
@@ -1176,7 +1176,14 @@ unsigned int SqliteNetworkController::_doCPGet(
 						sqlite3_bind_text(_sGetIpAssignmentsForNode2,2,addrs,10,SQLITE_STATIC);
 						bool firstIp = true;
 						while (sqlite3_step(_sGetIpAssignmentsForNode2) == SQLITE_ROW) {
-							InetAddress ip((const void *)sqlite3_column_blob(_sGetIpAssignmentsForNode2,0),(sqlite3_column_int(_sGetIpAssignmentsForNode2,2) == 6) ? 16 : 4,(unsigned int)sqlite3_column_int(_sGetIpAssignmentPools2,1));
+							int ipversion = sqlite3_column_int(_sGetIpAssignmentsForNode2,2);
+							char ipBlob[16];
+							memcpy(ipBlob,(const void *)sqlite3_column_blob(_sGetIpAssignmentsForNode2,0),16);
+							InetAddress ip(
+								(const void *)(ipversion == 6 ? ipBlob : &ipBlob[12]),
+								(ipversion == 6 ? 16 : 4),
+								(unsigned int)sqlite3_column_int(_sGetIpAssignmentsForNode2,1)
+							);
 							responseBody.append(firstIp ? "\"" : ",\"");
 							firstIp = false;
 							responseBody.append(_jsonEscape(ip.toString()));

--- a/node/Network.cpp
+++ b/node/Network.cpp
@@ -286,16 +286,9 @@ void Network::addMembershipCertificate(const CertificateOfMembership &cert,bool 
 			return;
 		}
 
-		SharedPtr<Peer> signer(RR->topology->getPeer(cert.signedBy()));
-
-		if (!signer) {
-			// This would be rather odd, since this is our controller... could happen
-			// if we get packets before we've gotten config.
-			RR->sw->requestWhois(cert.signedBy());
-			return;
-		}
-
-		if (!cert.verify(signer->identity())) {
+		// We are the controller: RR->identity.address() == controller() == cert.signedBy()
+		// So, verify that we signed th cert ourself
+		if (!cert.verify(RR->identity)) {
 			TRACE("rejected network membership certificate for %.16llx signed by %s: signature check failed",(unsigned long long)_id,cert.signedBy().toString().c_str());
 			return;
 		}

--- a/node/Node.hpp
+++ b/node/Node.hpp
@@ -214,12 +214,11 @@ private:
 
 	inline SharedPtr<Network> _network(uint64_t nwid) const
 	{
-		std::vector< SharedPtr<Network> >::const_iterator iter = std::lower_bound(_networks.begin(), _networks.end(), nwid, NetworkComparator());
-		if(iter != _networks.end() && (*iter)->id() == nwid) {
-			return *iter;
-		} else {
-			return SharedPtr<Network>();
+		for(std::vector< SharedPtr<Network> >::const_iterator iter(_networks.begin());iter!=_networks.end();++iter) {
+			if((*iter)->id() == nwid)
+				return *iter;
 		}
+		return SharedPtr<Network>();
 	}
 
 	RuntimeEnvironment _RR;


### PR DESCRIPTION
From my understanding, this is the problem that's fixed:

The only signing that's accepted is what we (the controller) signed.

	if (cert.signedBy() != controller()) then fail

So, since we're only accepting certs that should be singed by ourself (i.e. the controller), there's no need to get a Peer entry for ourself (which will fail). Just use our own (the controller) identity to verify the signing.