### PR TITLE
Fix for use of std::unique on std::vector

### DIFF
--- a/controller/SqliteNetworkController.cpp
+++ b/controller/SqliteNetworkController.cpp
@@ -389,9 +389,9 @@ NetworkController::ResultCode SqliteNetworkController::doNetworkConfigRequest(co
 					allowedEtherTypes.push_back(et);
 			}
 			std::sort(allowedEtherTypes.begin(),allowedEtherTypes.end());
-			for(std::vector<int>::iterator end = std::unique(allowedEtherTypes.begin(),allowedEtherTypes.end()) ; end != allowedEtherTypes.end() ; allowedEtherTypes.pop_back());
+			std::vector<int>::iterator end = std::unique(allowedEtherTypes.begin(),allowedEtherTypes.end());
 			std::string allowedEtherTypesCsv;
-			for(std::vector<int>::const_iterator i(allowedEtherTypes.begin());i!=allowedEtherTypes.end();++i) {
+			for(std::vector<int>::const_iterator i(allowedEtherTypes.begin());i!=end;++i) {
 				if (allowedEtherTypesCsv.length())
 					allowedEtherTypesCsv.push_back(',');
 				char tmp[16];

--- a/controller/SqliteNetworkController.cpp
+++ b/controller/SqliteNetworkController.cpp
@@ -389,7 +389,7 @@ NetworkController::ResultCode SqliteNetworkController::doNetworkConfigRequest(co
 					allowedEtherTypes.push_back(et);
 			}
 			std::sort(allowedEtherTypes.begin(),allowedEtherTypes.end());
-			std::unique(allowedEtherTypes.begin(),allowedEtherTypes.end());
+			for(std::vector<int>::iterator end = std::unique(allowedEtherTypes.begin(),allowedEtherTypes.end()) ; end != allowedEtherTypes.end() ; allowedEtherTypes.pop_back());
 			std::string allowedEtherTypesCsv;
 			for(std::vector<int>::const_iterator i(allowedEtherTypes.begin());i!=allowedEtherTypes.end();++i) {
 				if (allowedEtherTypesCsv.length())

--- a/node/CertificateOfMembership.cpp
+++ b/node/CertificateOfMembership.cpp
@@ -140,7 +140,7 @@ void CertificateOfMembership::fromString(const char *s)
 	}
 
 	std::sort(_qualifiers.begin(),_qualifiers.end());
-	std::unique(_qualifiers.begin(),_qualifiers.end());
+	for(std::vector<_Qualifier>::iterator end = std::unique(_qualifiers.begin(),_qualifiers.end()) ; end != _qualifiers.end() ; _qualifiers.pop_back());
 }
 
 bool CertificateOfMembership::agreesWith(const CertificateOfMembership &other) const

--- a/node/Network.cpp
+++ b/node/Network.cpp
@@ -502,7 +502,7 @@ std::vector<MulticastGroup> Network::_allMulticastGroups() const
 	if ((_config)&&(_config->enableBroadcast()))
 		mgs.push_back(Network::BROADCAST);
 	std::sort(mgs.begin(),mgs.end());
-	std::unique(mgs.begin(),mgs.end());
+	for(std::vector<MulticastGroup>::iterator end = std::unique(mgs.begin(),mgs.end()) ; end != mgs.end() ; mgs.pop_back());
 	return mgs;
 }
 

--- a/node/NetworkConfig.cpp
+++ b/node/NetworkConfig.cpp
@@ -145,7 +145,7 @@ void NetworkConfig::_fromDictionary(const Dictionary &d)
 	if (_staticIps.size() > ZT1_MAX_ZT_ASSIGNED_ADDRESSES)
 		throw std::invalid_argument("too many ZT-assigned IP addresses");
 	std::sort(_staticIps.begin(),_staticIps.end());
-	std::unique(_staticIps.begin(),_staticIps.end());
+	for (std::vector<InetAddress>::iterator end = std::unique(_staticIps.begin(),_staticIps.end()) ; end != _staticIps.end() ; _staticIps.pop_back());
 
 	std::vector<std::string> gatewaysSplit(Utils::split(d.get(ZT_NETWORKCONFIG_DICT_KEY_GATEWAYS,"").c_str(),",","",""));
 	for(std::vector<std::string>::const_iterator gwstr(gatewaysSplit.begin());gwstr!=gatewaysSplit.end();++gwstr) {
@@ -163,7 +163,7 @@ void NetworkConfig::_fromDictionary(const Dictionary &d)
 		}
 	}
 	std::sort(_activeBridges.begin(),_activeBridges.end());
-	std::unique(_activeBridges.begin(),_activeBridges.end());
+	for(std::vector<Address>::iterator end = std::unique(_activeBridges.begin(),_activeBridges.end()) ; end != _activeBridges.end() ; _activeBridges.pop_back());
 
 	std::vector<std::string> relaysSplit(Utils::split(d.get(ZT_NETWORKCONFIG_DICT_KEY_RELAYS,"").c_str(),",","",""));
 	for(std::vector<std::string>::const_iterator r(relaysSplit.begin());r!=relaysSplit.end();++r) {
@@ -177,7 +177,7 @@ void NetworkConfig::_fromDictionary(const Dictionary &d)
 		}
 	}
 	std::sort(_relays.begin(),_relays.end());
-	std::unique(_relays.begin(),_relays.end());
+	for(std::vector< std::pair<Address,InetAddress> >::iterator end = std::unique(_relays.begin(),_relays.end()) ; end != _relays.end() ; _relays.pop_back());
 
 	_com.fromString(d.get(ZT_NETWORKCONFIG_DICT_KEY_CERTIFICATE_OF_MEMBERSHIP,std::string()));
 }

--- a/node/Node.cpp
+++ b/node/Node.cpp
@@ -251,7 +251,7 @@ ZT1_ResultCode Node::processBackgroundTasks(uint64_t now,volatile uint64_t *next
 
 			// Attempt to contact network preferred relays that we don't have direct links to
 			std::sort(networkRelays.begin(),networkRelays.end());
-			std::unique(networkRelays.begin(),networkRelays.end());
+			for(std::vector< std::pair<Address,InetAddress> >::iterator end = std::unique(networkRelays.begin(),networkRelays.end()) ; end != networkRelays.end() ; networkRelays.pop_back());
 			for(std::vector< std::pair<Address,InetAddress> >::const_iterator nr(networkRelays.begin());nr!=networkRelays.end();++nr) {
 				if (nr->second) {
 					SharedPtr<Peer> rp(RR->topology->getPeer(nr->first));

--- a/osdep/BSDEthernetTap.cpp
+++ b/osdep/BSDEthernetTap.cpp
@@ -304,7 +304,7 @@ std::vector<InetAddress> BSDEthernetTap::ips() const
 		freeifaddrs(ifa);
 
 	std::sort(r.begin(),r.end());
-	std::unique(r.begin(),r.end());
+	for(std::vector<InetAddress>::iterator end = std::unique(r.begin(),r.end()) ; end != r.end() ; r.pop_back());
 
 	return r;
 }
@@ -355,7 +355,7 @@ void BSDEthernetTap::scanMulticastGroups(std::vector<MulticastGroup> &added,std:
 		newGroups.push_back(MulticastGroup::deriveMulticastGroupForAddressResolution(*ip));
 
 	std::sort(newGroups.begin(),newGroups.end());
-	std::unique(newGroups.begin(),newGroups.end());
+	for(std::vector<MulticastGroup>::iterator end = std::unique(newGroups.begin(),newGroups.end()) ; end != newGroups.end() ; newGroups.pop_back());
 
 	for(std::vector<MulticastGroup>::iterator m(newGroups.begin());m!=newGroups.end();++m) {
 		if (!std::binary_search(_multicastGroups.begin(),_multicastGroups.end(),*m))

--- a/osdep/LinuxEthernetTap.cpp
+++ b/osdep/LinuxEthernetTap.cpp
@@ -300,7 +300,7 @@ std::vector<InetAddress> LinuxEthernetTap::ips() const
 		freeifaddrs(ifa);
 
 	std::sort(r.begin(),r.end());
-	std::unique(r.begin(),r.end());
+	for(std::vector<InetAddress>::iterator end = std::unique(r.begin(),r.end()) ; end != r.end() ; r.pop_back());
 
 	return r;
 }
@@ -362,7 +362,7 @@ void LinuxEthernetTap::scanMulticastGroups(std::vector<MulticastGroup> &added,st
 		newGroups.push_back(MulticastGroup::deriveMulticastGroupForAddressResolution(*ip));
 
 	std::sort(newGroups.begin(),newGroups.end());
-	std::unique(newGroups.begin(),newGroups.end());
+	for(std::vector<MulticastGroup>::iterator end = std::unique(newGroups.begin(),newGroups.end()); end != newGroups.end() ; newGroups.pop_back());
 
 	for(std::vector<MulticastGroup>::iterator m(newGroups.begin());m!=newGroups.end();++m) {
 		if (!std::binary_search(_multicastGroups.begin(),_multicastGroups.end(),*m))

--- a/osdep/OSXEthernetTap.cpp
+++ b/osdep/OSXEthernetTap.cpp
@@ -564,7 +564,7 @@ std::vector<InetAddress> OSXEthernetTap::ips() const
 		freeifaddrs(ifa);
 
 	std::sort(r.begin(),r.end());
-	std::unique(r.begin(),r.end());
+	for(std::vector<InetAddress>::iterator end = std::unique(r.begin(),r.end()) ; end != r.end() ; r.pop_back());
 
 	return r;
 }
@@ -615,7 +615,7 @@ void OSXEthernetTap::scanMulticastGroups(std::vector<MulticastGroup> &added,std:
 		newGroups.push_back(MulticastGroup::deriveMulticastGroupForAddressResolution(*ip));
 
 	std::sort(newGroups.begin(),newGroups.end());
-	std::unique(newGroups.begin(),newGroups.end());
+	for(std::vector<MulticastGroup>::iterator end = std::unique(newGroups.begin(),newGroups.end()) ; end != newGroups.end() ; newGroups.pop_back());
 
 	for(std::vector<MulticastGroup>::iterator m(newGroups.begin());m!=newGroups.end();++m) {
 		if (!std::binary_search(_multicastGroups.begin(),_multicastGroups.end(),*m))

--- a/osdep/WindowsEthernetTap.cpp
+++ b/osdep/WindowsEthernetTap.cpp
@@ -472,7 +472,7 @@ std::vector<InetAddress> WindowsEthernetTap::ips() const
 	} catch ( ... ) {} // sanity check, shouldn't happen unless out of memory
 
 	std::sort(addrs.begin(),addrs.end());
-	std::unique(addrs.begin(),addrs.end());
+	for(std::vector<InetAddress>::iterator end = std::unique(addrs.begin(),addrs.end()) ; end != addrs.end() ; addrs.pop_back());
 
 	return addrs;
 }
@@ -546,7 +546,7 @@ void WindowsEthernetTap::scanMulticastGroups(std::vector<MulticastGroup> &added,
 		newGroups.push_back(MulticastGroup::deriveMulticastGroupForAddressResolution(*ip));
 
 	std::sort(newGroups.begin(),newGroups.end());
-	std::unique(newGroups.begin(),newGroups.end());
+	for(std::vector<MulticastGroup>::iterator end = std::unique(newGroups.begin(),newGroups.end()) ; end != newGroups.end() ; newGroups.pop_back());
 
 	for(std::vector<MulticastGroup>::iterator m(newGroups.begin());m!=newGroups.end();++m) {
 		if (!std::binary_search(_multicastGroups.begin(),_multicastGroups.end(),*m))

--- a/service/OneService.cpp
+++ b/service/OneService.cpp
@@ -864,7 +864,8 @@ public:
 					for(unsigned int i=0;i<nwc->assignedAddressCount;++i)
 						newAssignedIps.push_back(InetAddress(nwc->assignedAddresses[i]));
 					std::sort(newAssignedIps.begin(),newAssignedIps.end());
-					std::unique(newAssignedIps.begin(),newAssignedIps.end());
+					for(std::vector<InetAddress>::iterator end = std::unique(newAssignedIps.begin(),newAssignedIps.end()) ; end != newAssignedIps.end() ; newAssignedIps.pop_back());
+
 					for(std::vector<InetAddress>::iterator ip(newAssignedIps.begin());ip!=newAssignedIps.end();++ip) {
 						if (!std::binary_search(assignedIps.begin(),assignedIps.end(),*ip))
 							t->second->addIp(*ip);


### PR DESCRIPTION
The std::unique function does update the values in the vector, but does not alter the length (i.e. the return value of .end() )

Example:
With the rules I had ethertypes 0000, 0800, 0000. The config (saved in /var/lib/zerotier/networks.d) had 0000, 0800, 0800. After popping the elements where end != vector.end(), the values became 0000, 0800.
