### PR TITLE
rename LIBS to LDLIBS and make it accessible from outside

### DIFF
--- a/make-linux.mk
+++ b/make-linux.mk
@@ -22,7 +22,7 @@ CC?=$(shell if [ -e /usr/bin/clang ]; then echo clang; else echo gcc; fi)
 CXX?=$(shell if [ -e /usr/bin/clang++ ]; then echo clang++; else echo g++; fi)
 INCLUDES=
 DEFS=
-LIBS=
+LDLIBS?=
 
 include objects.mk
 OBJS+=osdep/LinuxEthernetTap.o 
@@ -35,7 +35,7 @@ endif
 # Build with ZT_ENABLE_NETWORK_CONTROLLER=1 to build with the Sqlite network controller
 ifeq ($(ZT_ENABLE_NETWORK_CONTROLLER),1)
         DEFS+=-DZT_ENABLE_NETWORK_CONTROLLER 
-        LIBS+=-L/usr/local/lib -lsqlite3
+        LDLIBS+=-L/usr/local/lib -lsqlite3
         OBJS+=controller/SqliteNetworkController.o 
 endif
 
@@ -67,13 +67,13 @@ endif
 all:	one
 
 one:	$(OBJS) one.o
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o zerotier-one $(OBJS) one.o $(LIBS)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o zerotier-one $(OBJS) one.o $(LDLIBS)
 	$(STRIP) zerotier-one
 	ln -sf zerotier-one zerotier-idtool
 	ln -sf zerotier-one zerotier-cli
 
 selftest:	$(OBJS) selftest.o
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o zerotier-selftest selftest.o $(OBJS) $(LIBS)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o zerotier-selftest selftest.o $(OBJS) $(LDLIBS)
 	$(STRIP) zerotier-selftest
 
 installer: one FORCE


### PR DESCRIPTION
This is the last patch to make ZT compile for OpenWrt without any other changes. Also, the common name for LIBS seems to be LDLIBS (https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html). If you believe otherwise, feel free to close the pull request, but make LIBS extensible from outside. :-)