### PR TITLE
Increase maximum number of paths per IP scope to 4

### DIFF
--- a/node/Constants.hpp
+++ b/node/Constants.hpp
@@ -343,7 +343,7 @@
 /**
  * Maximum number of paths per IP scope (e.g. global, link-local) and family (e.g. v4/v6)
  */
-#define ZT_PUSH_DIRECT_PATHS_MAX_PER_SCOPE_AND_FAMILY 1
+#define ZT_PUSH_DIRECT_PATHS_MAX_PER_SCOPE_AND_FAMILY 4
 
 /**
  * A test pseudo-network-ID that can be joined


### PR DESCRIPTION
Otherwise, local discovered routes are ignored.
Don't know what the best value would be. Taking 4 for now.