### PR TITLE
.deb installer missing Section header

### DIFF
--- a/ext/installfiles/linux/DEBIAN/control.in
+++ b/ext/installfiles/linux/DEBIAN/control.in
@@ -4,6 +4,7 @@ Maintainer: ZeroTier, Inc. <contact@zerotier.com>
 Priority: optional
 Version: __VERSION__
 Installed-Size: 1024
+Section: net
 Homepage: https://github.com/zerotier/ZeroTierOne
 Description: ZeroTier One network virtualization service
  ZeroTier One is a fast, secure, and easy to use peer to peer network


### PR DESCRIPTION
Hi guys! 

The `Section` header on the deb installer `control` file is definitely optional, however, it breaks some automation using local deb repos. An example is installing with [reprepro](http://mirrorer.alioth.debian.org/), you will just get:
```
No section given for 'zerotier-one', skipping.
```  
This isn't particularly a problem because there is a flag to ignore this, but it breaks when doing auto-installation and sticking to the "rules". It would also be good in advance of a possible PPA or mirror opportunities ;) 