### PR TITLE
Remove explicit sys/sysctl.h includes

### DIFF
--- a/attic/OSXEthernetTap.cpp.pcap-with-bridge-test
+++ b/attic/OSXEthernetTap.cpp.pcap-with-bridge-test
@@ -43,7 +43,6 @@
 #include <sys/cdefs.h>
 #include <sys/uio.h>
 #include <sys/param.h>
-#include <sys/sysctl.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <netinet/in.h>

--- a/attic/OSXEthernetTap.cpp.utun-work-in-progress
+++ b/attic/OSXEthernetTap.cpp.utun-work-in-progress
@@ -43,7 +43,6 @@
 #include <sys/cdefs.h>
 #include <sys/uio.h>
 #include <sys/param.h>
-#include <sys/sysctl.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/sys_domain.h>

--- a/ext/libnatpmp/getgateway.c
+++ b/ext/libnatpmp/getgateway.c
@@ -96,7 +96,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef USE_SYSCTL_NET_ROUTE
 #include <stdlib.h>
-#include <sys/sysctl.h>
 #include <sys/socket.h>
 #include <net/route.h>
 #endif

--- a/osdep/BSDEthernetTap.cpp
+++ b/osdep/BSDEthernetTap.cpp
@@ -34,7 +34,6 @@
 #include <sys/cdefs.h>
 #include <sys/uio.h>
 #include <sys/param.h>
-#include <sys/sysctl.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <netinet/in.h>

--- a/osdep/ManagedRoute.cpp
+++ b/osdep/ManagedRoute.cpp
@@ -33,7 +33,6 @@
 #ifdef __UNIX_LIKE__
 #include <unistd.h>
 #include <sys/param.h>
-#include <sys/sysctl.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/wait.h>

--- a/osdep/OSXEthernetTap.cpp
+++ b/osdep/OSXEthernetTap.cpp
@@ -34,7 +34,6 @@
 #include <sys/cdefs.h>
 #include <sys/uio.h>
 #include <sys/param.h>
-#include <sys/sysctl.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <netinet/in.h>


### PR DESCRIPTION
Explicitly including sys/sysctl.h breaks the ability to build against muslc.