### PR TITLE
Quick and dirty implementation of network-specific netns settings.

### DIFF
--- a/service/OneService.hpp
+++ b/service/OneService.hpp
@@ -86,6 +86,11 @@ public:
 		 * Allow overriding of system default routes for "full tunnel" operation?
 		 */
 		bool allowDefault;
+
+		/**
+		 * Set a network namespace for the service
+		 */
+		std::string nsname;
 	};
 
 	/**


### PR DESCRIPTION
In reference to this forum topic:
https://www.zerotier.com/community/topic/94/question-change-netns-of-zerotier-network-device

I made a quick-and-dirty implementation of this network namespace feature. To use it,
1. create a network namespace, for example `ip netns add mynetns`
2. Add a value for "netns=" to /var/lib/zerotier-one/networks.d/#########.local.conf
3. Join the network

An example local.conf:

```
allowManaged=1
allowGlobal=0
allowDefault=0
netns=mynetns
```

The reason I call it 'quick and dirty' is that I didn't make any attempt to make it cross-platform clean. Also, I did not make it very robust for the case where the desired network namespace might not exist yet. It would be nice to automatically create it if necessary. Finally, it's just a cut-and-paste implementation. It would probably be desirable to create a class that would alter the network namespace in its constructor, then revert to its original namespace in its destructor. That way, there will be reliable cleanup when the class goes out of scope. The current implementation has a very C-like feel. Sorry, my C++ has gotten pretty rusty.

On a cursory scan, I didn't see an example of an OS-specific setting like this. Since there wasn't a precedent to follow, my intent here is only to prove the concept, leaving the question of how to best fit such a thing into the design for the maintainers to solve according to their preferences.
