### PR TITLE
allow user to specify arbitrary allowed IP networks in allowManaged

### DIFF
--- a/node/Buffer.hpp
+++ b/node/Buffer.hpp
@@ -61,11 +61,11 @@ public:
 	// STL container idioms
 	typedef unsigned char value_type;
 	typedef unsigned char * pointer;
-	typedef const unsigned char * const_pointer;
-	typedef unsigned char & reference;
-	typedef const unsigned char & const_reference;
-	typedef unsigned char * iterator;
-	typedef const unsigned char * const_iterator;
+	typedef const char * const_pointer;
+	typedef char & reference;
+	typedef const char & const_reference;
+	typedef char * iterator;
+	typedef const char * const_iterator;
 	typedef unsigned int size_type;
 	typedef int difference_type;
 	typedef std::reverse_iterator<iterator> reverse_iterator;

--- a/service/ControlPlane.cpp
+++ b/service/ControlPlane.cpp
@@ -121,6 +121,15 @@ static void _jsonAppend(unsigned int depth,std::string &buf,const ZT_VirtualNetw
 		case ZT_NETWORK_TYPE_PUBLIC:                     ntype = "PUBLIC"; break;
 	}
 
+	std::string allowManaged = (localSettings.allowManaged) ? "true" : "false";
+	if (localSettings.allowManagedWhitelist.size() != 0) {
+		allowManaged = "";
+		for (InetAddress address : localSettings.allowManagedWhitelist) {
+			if (allowManaged.size() != 0) allowManaged += ',';
+			allowManaged += address.toIpString() + "/" + std::to_string(address.netmaskBits());
+		}
+	}
+
 	Utils::snprintf(json,sizeof(json),
 		"%s{\n"
 		"%s\t\"id\": \"%.16llx\",\n"
@@ -158,7 +167,7 @@ static void _jsonAppend(unsigned int depth,std::string &buf,const ZT_VirtualNetw
 		prefix,_jsonEnumerate(nc->assignedAddresses,nc->assignedAddressCount).c_str(),
 		prefix,_jsonEnumerate(nc->routes,nc->routeCount).c_str(),
 		prefix,_jsonEscape(portDeviceName).c_str(),
-		prefix,(localSettings.allowManaged) ? "true" : "false",
+		prefix,allowManaged.c_str(),
 		prefix,(localSettings.allowGlobal) ? "true" : "false",
 		prefix,(localSettings.allowDefault) ? "true" : "false",
 		prefix);

--- a/service/OneService.hpp
+++ b/service/OneService.hpp
@@ -20,6 +20,7 @@
 #define ZT_ONESERVICE_HPP
 
 #include <string>
+#include <vector>
 
 namespace ZeroTier {
 
@@ -64,6 +65,12 @@ public:
 		 * Allow this network to configure IP addresses and routes?
 		 */
 		bool allowManaged;
+
+		/**
+		 * Whitelist of addresses that can be configured by this network.
+		 * If empty and allowManaged is true, allow all private/pseudoprivate addresses.
+		 */
+		std::vector<InetAddress> allowManagedWhitelist;
 
 		/**
 		 * Allow configuration of IPs and routes within global (Internet) IP space?


### PR DESCRIPTION
Implements #440. (I haven't tested this much yet)

There is also a fix for compilation problem in Buffer.hpp. It seems that Buffer::begin/Buffer::end was not previously used, so it wasn't catched.