### PR TITLE
Add make command for linux-build-farm

### DIFF
--- a/make-linux.mk
+++ b/make-linux.mk
@@ -186,6 +186,7 @@ uninstall:	FORCE
 # These are just for convenience for building Linux packages
 
 debian:	FORCE
+	make one
 	debuild -I -i -us -uc -nc -b
 
 redhat:	FORCE


### PR DESCRIPTION
Without the `make one` command in the Makefile, building the .deb packages using the linux-build-farm (which runs `make debian` inside a Docker container) fails when executed on a **non-Linux machine**. (e.g. macOS)