### PR TITLE
Wait for ZT networks to become available

### DIFF
--- a/debian/zerotier-one.service
+++ b/debian/zerotier-one.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=ZeroTier One
+Documentation=https://www.zerotier.com/manual.shtml
 After=network.target
 Before=ssh.service docker.service
 

--- a/debian/zerotier-one.service
+++ b/debian/zerotier-one.service
@@ -1,9 +1,15 @@
 [Unit]
 Description=ZeroTier One
 After=network.target
+Before=ssh.service docker.service
 
 [Service]
 ExecStart=/usr/sbin/zerotier-one
+ExecStartPost=/bin/bash -c '\
+until [ "`find /var/lib/zerotier-one/networks.d -type f -name "????????????????.conf" | \
+wc -l`" == "`find /sys/devices/virtual/net -type d -name "zt*" | wc -l`" ]; do \
+sleep 0.5; \
+done; echo "ZeroTier One networks are online";'
 Restart=always
 KillMode=process
 


### PR DESCRIPTION
It's not very pretty **but it works**. 😅
If you're running services like SSH, Docker etc. which _bind to a specific ZeroTier interface_, they will most likely fail during startup because `systemd` doesn't waits for ZT networks to come up.
Adding a this "dynamic" delay doesn't impact startup time in any substantial way.
Without this _small hack_, it's just random luck when e.g. Docker successfully starts after all configured ZT (networks) interfaces are up.

Tested on **Ubuntu 16.04** with ZeroTier One v1.1.17 and Docker 17.03 CE