### PR TITLE
Empty override means it doesn't build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -6,9 +6,6 @@ CXXFLAGS=-O3 -fstack-protector-strong
 %:
 	dh $@ --with systemd
 
-override_dh_auto_build:
-#	make -j 2
-
 override_dh_systemd_start:
 	dh_systemd_start --restart-after-upgrade
 

--- a/debian/rules.wheezy
+++ b/debian/rules.wheezy
@@ -5,7 +5,3 @@ CXXFLAGS=-O3 -fstack-protector
 
 %:
 	dh $@
-
-override_dh_auto_build:
-#	make -j 2
-


### PR DESCRIPTION
Having a blank override_dh_auto_build means it doesn't actually build anything. Either comment out entirely, or just remove it.