### PR TITLE
Fix empty override_dh_auto_build causing build failure

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -6,9 +6,6 @@ CXXFLAGS=-O3 -fstack-protector-strong
 %:
 	dh $@ --with systemd
 
-override_dh_auto_build:
-#	make -j 2
-
 override_dh_systemd_start:
 	dh_systemd_start --restart-after-upgrade
 

--- a/debian/rules.wheezy
+++ b/debian/rules.wheezy
@@ -6,6 +6,3 @@ CXXFLAGS=-O3 -fstack-protector
 %:
 	dh $@
 
-override_dh_auto_build:
-#	make -j 2
-


### PR DESCRIPTION
A blank debian/rules directive means nothing happens. In this case, it means the build process fails. Removing the empty directive lets builds continue correctly.