### PR TITLE
build: use clang on FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ ifeq ($(OSTYPE),Linux)
 endif
 
 ifeq ($(OSTYPE),FreeBSD)
-	CC=gcc
-	CXX=g++
+	CC=clang
+	CXX=clang++
 	ZT_BUILD_PLATFORM=7
 	include make-bsd.mk
 endif


### PR DESCRIPTION
- this avoids a whopping 500+Mb dependency on gcc and friends at runtime
- passes `zerotier selftest` at least

closes https://github.com/zerotier/ZeroTierOne/issues/456

```
$ git show HEAD
commit 25dc5963977a3ca7e8a2e6e09a3ed9a4d43fe527
Author: Dave Cottlehuber <dch@skunkwerks.at>
Date:   Thu Mar 16 12:58:04 2017 +0100

    build: use clang on FreeBSD

    this avoids a whopping 500+Mb dependency on gcc and friends at runtime

diff --git a/Makefile b/Makefile
index 2f11e5fa..95118621 100644
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ ifeq ($(OSTYPE),Linux)
 endif

 ifeq ($(OSTYPE),FreeBSD)
-       CC=gcc
-       CXX=g++
+       CC=clang
+       CXX=clang++
        ZT_BUILD_PLATFORM=7
        include make-bsd.mk
 endif
$ gmake
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o controller/EmbeddedNetworkController.o controller/EmbeddedNetworkController.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o controller/JSONDB.o controller/JSONDB.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o node/C25519.o node/C25519.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o node/Capability.o node/Capability.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o node/CertificateOfMembership.o node/CertificateOfMembership.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o node/CertificateOfOwnership.o node/CertificateOfOwnership.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o node/Cluster.o node/Cluster.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o node/Identity.o node/Identity.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o node/IncomingPacket.o node/IncomingPacket.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o node/InetAddress.o node/InetAddress.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o node/Membership.o node/Membership.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o node/Multicaster.o node/Multicaster.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o node/Network.o node/Network.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o node/NetworkConfig.o node/NetworkConfig.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o node/Node.o node/Node.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o node/OutboundMulticast.o node/OutboundMulticast.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o node/Packet.o node/Packet.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o node/Path.o node/Path.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o node/Peer.o node/Peer.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o node/Poly1305.o node/Poly1305.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o node/Revocation.o node/Revocation.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o node/Salsa20.o node/Salsa20.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o node/SelfAwareness.o node/SelfAwareness.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o node/SHA512.o node/SHA512.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o node/Switch.o node/Switch.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o node/Tag.o node/Tag.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o node/Topology.o node/Topology.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o node/Utils.o node/Utils.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o osdep/ManagedRoute.o osdep/ManagedRoute.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o osdep/Http.o osdep/Http.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o osdep/OSUtils.o osdep/OSUtils.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o service/ClusterGeoIpService.o service/ClusterGeoIpService.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o service/SoftwareUpdater.o service/SoftwareUpdater.cpp
service/SoftwareUpdater.cpp:261:110: warning: format specifies type 'unsigned long long' but the argument has type 'uint64_t' (aka 'unsigned long') [-Wformat]
  ...fprintf(_distLog,"%.10llx WARNING: bad update message verb==%u length==%u (unrecognized verb)" ZT_EOL_S,origin,(unsigned int)v,len);
                       ~~~~~~~                                                                               ^~~~~~
                       %.10lx
service/SoftwareUpdater.cpp:268:132: warning: format specifies type 'unsigned long long' but the argument has type 'uint64_t' (aka 'unsigned long') [-Wformat]
  ...fprintf(_distLog,"%.10llx WARNING: bad update message verb==%u length==%u (unexpected exception, likely invalid JSON)" ZT_EOL_S,origin,(unsigned int)v...
                       ~~~~~~~                                                                                                       ^~~~~~
                       %.10lx
2 warnings generated.
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o osdep/BSDEthernetTap.o osdep/BSDEthernetTap.cpp
clang -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\""   -c -o ext/http-parser/http_parser.o ext/http-parser/http_parser.c
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o service/OneService.o service/OneService.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o one.o one.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1 -pie -Wl,-z,relro,-z,now -o zerotier-one controller/EmbeddedNetworkController.o controller/JSONDB.o node/C25519.o node/Capability.o node/CertificateOfMembership.o node/CertificateOfOwnership.o node/Cluster.o node/Identity.o node/IncomingPacket.o node/InetAddress.o node/Membership.o node/Multicaster.o node/Network.o node/NetworkConfig.o node/Node.o node/OutboundMulticast.o node/Packet.o node/Path.o node/Peer.o node/Poly1305.o node/Revocation.o node/Salsa20.o node/SelfAwareness.o node/SHA512.o node/Switch.o node/Tag.o node/Topology.o node/Utils.o osdep/ManagedRoute.o osdep/Http.o osdep/OSUtils.o service/ClusterGeoIpService.o service/SoftwareUpdater.o osdep/BSDEthernetTap.o ext/http-parser/http_parser.o service/OneService.o one.o
strip --strip-all zerotier-one
ln -sf zerotier-one zerotier-idtool
ln -sf zerotier-one zerotier-cli

$ gmake selftest
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1   -c -o selftest.o selftest.cpp
clang++ -O3 -fstack-protector -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11 -D_GLIBCXX_USE_C99 -D_GLIBCXX_USE_C99_MATH -D_GLIBCXX_USE_C99_MATH_TR1 -pie -Wl,-z,relro,-z,now -o zerotier-selftest selftest.o controller/EmbeddedNetworkController.o controller/JSONDB.o node/C25519.o node/Capability.o node/CertificateOfMembership.o node/CertificateOfOwnership.o node/Cluster.o node/Identity.o node/IncomingPacket.o node/InetAddress.o node/Membership.o node/Multicaster.o node/Network.o node/NetworkConfig.o node/Node.o node/OutboundMulticast.o node/Packet.o node/Path.o node/Peer.o node/Poly1305.o node/Revocation.o node/Salsa20.o node/SelfAwareness.o node/SHA512.o node/Switch.o node/Tag.o node/Topology.o node/Utils.o osdep/ManagedRoute.o osdep/Http.o osdep/OSUtils.o service/ClusterGeoIpService.o service/SoftwareUpdater.o osdep/BSDEthernetTap.o ext/http-parser/http_parser.o
strip --strip-all zerotier-selftest

$ ./zerotier-selftest
[info] sizeof(void *) == 8
[info] sizeof(NetworkConfig) == 431496
[other] Testing Hashtable... PASS
[other] Testing hex encode/decode... PASS
[other] Testing/fuzzing Dictionary... PASS (junk value to prevent optimization-out of test: -17891)
[crypto] getSecureRandom: 03db82b85a985aeef837c9dbfd72311ebf8a6fa4f4bc33c42aa39c8f817b17a6103bdcaac6d72a284fb014b59b3f89a80d41e471620bb16b73d875752c218f96
[crypto] getSecureRandom: b52cb7da8d4ed4ff8f8d78f7d8310e7ba32d2e3a5107f5ed11219a3e1222a721876dc6a0018561149c7a13d86749e14277a66f826f650758e583b666f7939d14
[crypto] getSecureRandom: 9dc2cb19225177749355cfd0c793bf44946555411d8880a4dcd4929e4527828fca9f41113853e000c0a20deded41c8f55633bacf3902e39d813908c1f8a01a8e
[crypto] Testing Salsa20... PASS
[crypto] Salsa20 SSE: ENABLED
[crypto] Benchmarking Salsa20/12... 888.585 MiB/second (f31ddbcdb3b69d0a5e19ba94a7e2facc)
[crypto] Benchmarking Salsa20/20... 550.175 MiB/second (24c619994ae7f1549136169c9072f3d7)
[crypto] Testing SHA-512... PASS
[crypto] Testing Poly1305... PASS
[crypto] Benchmarking Poly1305... 1220.08 MiB/second
[crypto] Testing C25519 and Ed25519 against test vectors... PASS
[crypto] Testing C25519 ECC key agreement... PASS
[crypto] Benchmarking C25519 ECC key agreement... 1.94ms per agreement.
[crypto] Testing Ed25519 ECC signatures... PASS
[packet] Testing Packet encoder/decoder... (compressed: 77, decompressed: 1116) PASS
[identity] Validate known-good identity... PASS (19.8ms per validation)
[identity] Validate known-bad identity... PASS (i.e. it failed)
[identity] Generate identity... (took 105ms): 4137fb91a5:0:178ae75f22bb62961bcf1b8dfae422c6f71893732a27f00462c320e838b42f237a37a37bd397cdd49521c63a2d10fdb81a43c362c62fc9c6758e5ae0e452083f:147e490033ef50cb1e130fd033a6a2f2224666f25e14adf4319343547181e6bd8da5353f2054d05f10696756c1a18b33d4fd45d5d849d669b36cae500c195bf5
[identity] Locally validate identity: PASS
[identity] Generate identity... (took 352ms): 14706b535f:0:9a53fe713535f0acb4891be5154353ef589ca453b6d9a22e7d2ae9e29f44cd44cbd052abc28694353719e44824248e84a86542ef9b246723b3f415b0359225d9:e762328d822812318a205d690d9365be7c140e722148b0b61cf2d0aa5ee782745e7cbe6f53915a66eee20a2882f7eec01e95c6e12d115a96ed9485687ef30ced
[identity] Locally validate identity: PASS
[identity] Generate identity... (took 187ms): ddb1329100:0:b0288e2cbece0a8513a1e8fdcdf0b33b7678822e8db58f6c51403d294007fe7969cb973a34abda7cc5166593f8991afa058bf2d5b48e88d5f32306237e57e66d:ef019663074289b34502d6afd83ed7c0ba639e4acce0e07748ba0d99dfa8622cecdf04afbc8e501bfe4259c95a7996fb71d4210b90c5277886b668b5fb08b56c
[identity] Locally validate identity: PASS
[identity] Generate identity... (took 160ms): 517116edd5:0:cf5e8339b77a0593f820d68bc1d5e4507d5dcf3ea25a87e5e850e21eb142b276c4d04bf7d84209485e5d608768b36c3eff797aa01705650db92e7c3fd64b0482:ad8f36a96ffc945e5db3595c8d1dbcf0706a0f7778c28c99ba4a405ff11616c66d6528d4c90c22cdf2c327dc2983c0454ea8661a1b478f8dc2e26300ada3611e
[identity] Locally validate identity: PASS
[identity] Serialize and deserialize (w/private): PASS
[identity] Serialize and deserialize (no private): PASS
[identity] Serialize and deserialize (ASCII w/private): PASS
[identity] Serialize and deserialize (ASCII no private): PASS
[certificate] Generating identity to act as authority... 2854f72334
[certificate] Generating identities A and B... 47f54954a9, 1d8297829d
[certificate] Generating certificates A and B...
[certificate] Signing certificates A and B with authority...
[certificate] A agrees with B and B with A... yes, yes.
[certificate] Generating two certificates that should not agree...
[certificate] A agrees with B and B with A... no, no.
[phy] Creating phy endpoint...
[phy] Binding UDP listen socket to 127.0.0.1/60002... OK
[phy] Binding TCP listen socket to 127.0.0.1/60002... OK
[phy] Testing UDP send/receive... got 10000 packets, OK
[phy] Testing TCP... got 10 connect successes, 2 failures, and 10000000 bytes, OK
$
```