### PR TITLE
use system libs for json and http-parser

### DIFF
--- a/controller/EmbeddedNetworkController.hpp
+++ b/controller/EmbeddedNetworkController.hpp
@@ -39,7 +39,11 @@
 #include "../osdep/Thread.hpp"
 #include "../osdep/BlockingQueue.hpp"
 
+#ifdef ZT_USE_SYSTEM_JSON
+#include <json.hpp>
+#else
 #include "../ext/json/json.hpp"
+#endif
 
 #include "JSONDB.hpp"
 

--- a/controller/JSONDB.hpp
+++ b/controller/JSONDB.hpp
@@ -31,7 +31,13 @@
 
 #include "../node/Constants.hpp"
 #include "../node/Utils.hpp"
+
+#ifdef ZT_USE_SYSTEM_JSON
+#include <json.hpp>
+#else
 #include "../ext/json/json.hpp"
+#endif
+
 #include "../osdep/OSUtils.hpp"
 
 namespace ZeroTier {

--- a/make-linux.mk
+++ b/make-linux.mk
@@ -16,7 +16,13 @@ include objects.mk
 
 # Use bundled http-parser since distribution versions are NOT API-stable or compatible!
 # Trying to use dynamically linked libhttp-parser causes tons of compatibility problems.
-OBJS+=ext/http-parser/http_parser.o
+#OBJS+=ext/http-parser/http_parser.o
+
+# Use system json
+DEFS+=-DZT_USE_SYSTEM_JSON
+# Use system http-parser
+DEFS+=-DZT_USE_SYSTEM_HTTP_PARSER
+LDLIBS+=-lhttp_parser
 
 # Auto-detect miniupnpc and nat-pmp as well and use system libs if present,
 # otherwise build into binary as done on Mac and Windows.

--- a/one.cpp
+++ b/one.cpp
@@ -76,7 +76,11 @@
 
 #include "service/OneService.hpp"
 
+#ifdef ZT_USE_SYSTEM_JSON
+#include <json.hpp>
+#else
 #include "ext/json/json.hpp"
+#endif
 
 #define ZT_PID_PATH "zerotier-one.pid"
 

--- a/osdep/OSUtils.hpp
+++ b/osdep/OSUtils.hpp
@@ -45,7 +45,11 @@
 #include <arpa/inet.h>
 #endif
 
+#ifdef ZT_USE_SYSTEM_JSON
+#include <json.hpp>
+#else
 #include "../ext/json/json.hpp"
+#endif
 
 namespace ZeroTier {
 

--- a/service/OneService.cpp
+++ b/service/OneService.cpp
@@ -73,7 +73,11 @@
 #include "../ext/http-parser/http_parser.h"
 #endif
 
+#ifdef ZT_USE_SYSTEM_JSON
+#include <json.hpp>
+#else
 #include "../ext/json/json.hpp"
+#endif
 
 using json = nlohmann::json;
 

--- a/service/SoftwareUpdater.hpp
+++ b/service/SoftwareUpdater.hpp
@@ -32,7 +32,11 @@
 #include "../node/Array.hpp"
 #include "../node/Packet.hpp"
 
+#ifdef ZT_USE_SYSTEM_JSON
+#include <json.hpp>
+#else
 #include "../ext/json/json.hpp"
+#endif
 
 /**
  * VERB_USER_MESSAGE type ID for software update messages


### PR DESCRIPTION
This patch introduces the option to use the system library for json instead of the one in the "ext" directory. 

The makefile needs work, as now I hard coded the use of the system libraries (both json and http-parser), which will obviously not work for regular builds.