### PR TITLE
build: all BSDs expect gmake here

### DIFF
--- a/make-bsd.mk
+++ b/make-bsd.mk
@@ -142,7 +142,7 @@ clean:
 	rm -rf *.o node/*.o controller/*.o osdep/*.o service/*.o ext/http-parser/*.o build-* zerotier-one zerotier-idtool zerotier-selftest zerotier-cli ZeroTierOneInstaller-* $(OBJS)
 
 debug:	FORCE
-	make -j 4 ZT_DEBUG=1
+	gmake -j 4 ZT_DEBUG=1
 
 install:	one
 	rm -f /usr/local/sbin/zerotier-one


### PR DESCRIPTION
The provided `make ...` command would not have worked on any of the BSDs, which have GNU make
installed via ports as `gmake`. I've not tested this on the other flavours but just google-checked this.

This resolves #529 by using the provided makefile target, will be included in next revision of the FreeBSD
port to toggle debugging.
