### PR TITLE
Java fixup/1

### DIFF
--- a/java/src/com/zerotier/sdk/DataStoreGetListener.java
+++ b/java/src/com/zerotier/sdk/DataStoreGetListener.java
@@ -48,7 +48,6 @@ public interface DataStoreGetListener {
      * @param out_buffer buffer to put the object in
      * @return size of the object
      */
-    public long onDataStoreGet(
-            String name,
-            byte[] out_buffer);
+    long onDataStoreGet(String name, byte[] out_buffer);
+
 }

--- a/java/src/com/zerotier/sdk/DataStorePutListener.java
+++ b/java/src/com/zerotier/sdk/DataStorePutListener.java
@@ -34,7 +34,7 @@ public interface DataStorePutListener {
      * <p>If secure is true, the file should be set readable and writable only
      * to the user running ZeroTier One. What this means is platform-specific.</p>
      *
-     * <p>Name semantics are the same as {@link DataStoreGetListener}. This must return 
+     * <p>Name semantics are the same as {@link DataStoreGetListener}. This must return
      * zero on success. You can return any OS-specific error code on failure, as these
      * may be visible in logs or error messages and might aid in debugging.</p>
      *
@@ -43,17 +43,13 @@ public interface DataStorePutListener {
      * @param secure set to user read/write only.
      * @return 0 on success.
      */
-    public int onDataStorePut(
-        String name,
-        byte[] buffer,
-        boolean secure);
+    int onDataStorePut(String name, byte[] buffer, boolean secure);
 
     /**
      * Function to delete an object from the data store
-     * 
+     *
      * @param name Object name
      * @return 0 on success.
      */
-    public int onDelete(
-        String name);
+    int onDelete(String name);
 }

--- a/java/src/com/zerotier/sdk/EventListener.java
+++ b/java/src/com/zerotier/sdk/EventListener.java
@@ -24,7 +24,6 @@
  * redistribute it in a modified binary form, please contact ZeroTier Networks
  * LLC. Start here: http://www.zerotier.com/
  */
-
 package com.zerotier.sdk;
 
 import java.net.InetSocketAddress;
@@ -36,17 +35,18 @@ import java.lang.String;
 public interface EventListener {
     /**
      * Callback for events with no other associated metadata
-     * 
+     *
      * @param event {@link Event} enum
      */
-    public void onEvent(Event event);
-    
+    void onEvent(Event event);
+
     /**
      * Trace messages
-     * 
+     *
      * <p>These events are only generated if the underlying ZeroTierOne SDK is a TRACE-enabled build.</p>
      *
      * @param message the trace message
      */
-    public void onTrace(String message);
+    void onTrace(String message);
+
 }

--- a/java/src/com/zerotier/sdk/PacketSender.java
+++ b/java/src/com/zerotier/sdk/PacketSender.java
@@ -28,7 +28,6 @@ package com.zerotier.sdk;
 
 import java.net.InetSocketAddress;
 
-
 public interface PacketSender {
     /**
      * Function to send a ZeroTier packet out over the wire
@@ -40,11 +39,8 @@ public interface PacketSender {
      * @param localSocket socket file descriptor to send from.  Set to -1 if not specified.
      * @param remoteAddr {@link InetSocketAddress} to send to
      * @param packetData data to send
+     * @param ttl time to live
      * @return 0 on success, any error code on failure.
      */
-    public int onSendPacketRequested(
-            long localSocket,
-            InetSocketAddress remoteAddr,
-            byte[] packetData,
-            int ttl);
+    int onSendPacketRequested(long localSocket, InetSocketAddress remoteAddr, byte[] packetData, int ttl);
 }

--- a/java/src/com/zerotier/sdk/PathChecker.java
+++ b/java/src/com/zerotier/sdk/PathChecker.java
@@ -2,7 +2,6 @@
  * ZeroTier One - Network Virtualization Everywhere
  * Copyright (C) 2011-2017  ZeroTier, Inc.  https://www.zerotier.com/
  */
-
 package com.zerotier.sdk;
 
 import java.net.InetSocketAddress;

--- a/java/src/com/zerotier/sdk/VirtualNetworkConfigListener.java
+++ b/java/src/com/zerotier/sdk/VirtualNetworkConfigListener.java
@@ -24,10 +24,7 @@
  * redistribute it in a modified binary form, please contact ZeroTier Networks
  * LLC. Start here: http://www.zerotier.com/
  */
-
-
 package com.zerotier.sdk;
-
 
 public interface VirtualNetworkConfigListener {
     /**
@@ -53,8 +50,5 @@ public interface VirtualNetworkConfigListener {
      * @param config {@link VirtualNetworkConfig} object with the new configuration
      * @return 0 on success
      */
-    public int onNetworkConfigurationUpdated(
-            long nwid,
-            VirtualNetworkConfigOperation op,
-            VirtualNetworkConfig config);
+    int onNetworkConfigurationUpdated(long nwid, VirtualNetworkConfigOperation op, VirtualNetworkConfig config);
 }

--- a/java/src/com/zerotier/sdk/VirtualNetworkFrameListener.java
+++ b/java/src/com/zerotier/sdk/VirtualNetworkFrameListener.java
@@ -24,25 +24,18 @@
  * redistribute it in a modified binary form, please contact ZeroTier Networks
  * LLC. Start here: http://www.zerotier.com/
  */
-
 package com.zerotier.sdk;
 
 public interface VirtualNetworkFrameListener {
     /**
      * Function to send a frame out to a virtual network port
-     * 
+     *
      * @param nwid ZeroTier One network ID
      * @param srcMac source MAC address
      * @param destMac destination MAC address
-     * @param ethertype
-     * @param vlanId
+     * @param ethertype ethertype
+     * @param vlanId vlan id
      * @param frameData data to send
      */
-    public void onVirtualNetworkFrame(
-                long nwid,
-                long srcMac,
-                long destMac,
-                long etherType,
-                long vlanId,
-                byte[] frameData);
+    void onVirtualNetworkFrame(long nwid, long srcMac, long destMac, long etherType, long vlanId, byte[] frameData);
 }


### PR DESCRIPTION
In Java:
    
 * methods in interfaces are public by default
 * not traditionally broken at a short column length
    
Some little other tidy-ups.
    
-=david=-
