### PR TITLE
Update make-linux.mk to include support for Armv7l

### DIFF
--- a/make-linux.mk
+++ b/make-linux.mk
@@ -130,6 +130,11 @@ ifeq ($(CC_MACH),armv7)
 	override DEFS+=-DZT_NO_TYPE_PUNNING
 	ZT_USE_ARM32_NEON_ASM_SALSA2012=1
 endif
+ifeq ($(CC_MACH),armv7l)
+        ZT_ARCHITECTURE=3
+	override DEFS+=-DZT_NO_TYPE_PUNNING
+	ZT_USE_ARM32_NEON_ASM_SALSA2012=1
+endif
 ifeq ($(CC_MACH),arm64)
         ZT_ARCHITECTURE=4
 	override DEFS+=-DZT_NO_TYPE_PUNNING


### PR DESCRIPTION
When running ArchlinuxARM with 64bit support on Raspberry Pi3, the default build fails due to the architecture look-up at the beginning of the build process. A simple addition of the Armv7l section above allows the build to continue and successfully run.