### PR TITLE
Add support for armv7l

### DIFF
--- a/make-linux.mk
+++ b/make-linux.mk
@@ -130,6 +130,11 @@ ifeq ($(CC_MACH),armv7)
 	override DEFS+=-DZT_NO_TYPE_PUNNING
 	ZT_USE_ARM32_NEON_ASM_SALSA2012=1
 endif
+ifeq ($(CC_MACH),armv7l)
+        ZT_ARCHITECTURE=3
+	override DEFS+=-DZT_NO_TYPE_PUNNING
+	ZT_USE_ARM32_NEON_ASM_SALSA2012=1
+endif
 ifeq ($(CC_MACH),arm64)
         ZT_ARCHITECTURE=4
 	override DEFS+=-DZT_NO_TYPE_PUNNING


### PR DESCRIPTION
* GCC running on Raspberry Pi 3 on Arch linux ARM reports arch as
  armv7l-unknown-linux-gnueabihf

```
[aco@pi ~]$ uname -m
armv7l
[aco@pi ~]$ gcc -dumpmachine
armv7l-unknown-linux-gnueabihf
```

Tested and working.

Solves https://github.com/zerotier/ZeroTierOne/issues/601