### PR TITLE
Simplify JoinNetworkView

### DIFF
--- a/windows/WinUI/App.config
+++ b/windows/WinUI/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>
     </startup>
 </configuration>

--- a/windows/WinUI/FodyWeavers.xml
+++ b/windows/WinUI/FodyWeavers.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Weavers>
+    <PropertyChanged/>
+</Weavers>

--- a/windows/WinUI/JoinNetworkView.xaml
+++ b/windows/WinUI/JoinNetworkView.xaml
@@ -5,12 +5,17 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:WinUI"
         mc:Ignorable="d"
-        Title="Join a Network" SizeToContent="WidthAndHeight" Height="Auto" Width="Auto" Icon="ZeroTierIcon.ico">
+        Title="Join a Network"
+        SizeToContent="WidthAndHeight"
+        Height="Auto"
+        Width="Auto"
+        Icon="ZeroTierIcon.ico"
+        DataContext="{Binding RelativeSource={RelativeSource Self}}">
     <Grid HorizontalAlignment="Left" Margin="0,0,0,0" Width="315">
-        <TextBox x:Name="joinNetworkBox" HorizontalAlignment="Left" Height="23" Margin="10,10,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="291" PreviewTextInput="joinNetworkBox_OnTextEntered" PreviewKeyDown="joinNetworkBox_OnKeyDown"/>
-        <CheckBox x:Name="allowManagedCheckbox" Content="Allow Managed" HorizontalAlignment="Left" Margin="10,38,0,0" VerticalAlignment="Top" IsChecked="True"/>
-        <CheckBox x:Name="allowGlobalCheckbox" Content="Allow Global" HorizontalAlignment="Left" Margin="118,38,0,0" VerticalAlignment="Top"/>
-        <CheckBox x:Name="allowDefaultCheckbox" Content="Allow Default" HorizontalAlignment="Left" Margin="210,38,-6,0" VerticalAlignment="Top"/>
-        <Button x:Name="joinButton" Content="Join" HorizontalAlignment="Left" Margin="226,58,0,10" Background="#FFFFB354" VerticalAlignment="Top" Width="75" Click="joinButton_Click" IsEnabled="False"/>
+        <TextBox x:Name="joinNetworkBox" HorizontalAlignment="Left" Height="23" Margin="10,10,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="291" Text="{Binding NetworkID, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+        <CheckBox x:Name="allowManagedCheckbox" Content="Allow Managed" HorizontalAlignment="Left" Margin="10,38,0,0" VerticalAlignment="Top" IsChecked="{Binding AllowManaged, Mode=TwoWay}"/>
+        <CheckBox x:Name="allowGlobalCheckbox" Content="Allow Global" HorizontalAlignment="Left" Margin="118,38,0,0" VerticalAlignment="Top" IsChecked="{Binding AllowGlobal, Mode=TwoWay}"/>
+        <CheckBox x:Name="allowDefaultCheckbox" Content="Allow Default" HorizontalAlignment="Left" Margin="210,38,-6,0" VerticalAlignment="Top" IsChecked="{Binding AllowDefault, Mode=TwoWay}"/>
+        <Button x:Name="joinButton" Content="Join" HorizontalAlignment="Left" Margin="226,58,0,10" Background="#FFFFB354" VerticalAlignment="Top" Width="75" Click="joinButton_Click" IsEnabled="{Binding JoinEnabled, Mode=TwoWay}"/>
     </Grid>
 </Window>

--- a/windows/WinUI/JoinNetworkView.xaml.cs
+++ b/windows/WinUI/JoinNetworkView.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -18,107 +19,39 @@ namespace WinUI
     /// <summary>
     /// Interaction logic for JoinNetworkView.xaml
     /// </summary>
-    public partial class JoinNetworkView : Window
+    public partial class JoinNetworkView : Window, INotifyPropertyChanged
     {
-        Regex charRegex = new Regex("[0-9a-fxA-FX]");
         Regex wholeStringRegex = new Regex("^[0-9a-fxA-FX]+$");
 
         public JoinNetworkView()
         {
             InitializeComponent();
-
-            DataObject.AddPastingHandler(joinNetworkBox, onPaste);
-            DataObject.AddCopyingHandler(joinNetworkBox, onCopyCut);
         }
 
-        private void joinNetworkBox_OnTextEntered(object sender, TextCompositionEventArgs e)
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private string networkID = "";
+
+        public string NetworkID
         {
-            e.Handled = !charRegex.IsMatch(e.Text);
-
-            if ( (joinNetworkBox.Text.Length + e.Text.Length) == 16)
+            get
             {
-                joinButton.IsEnabled = true;
+                return networkID;
             }
-            else
+            set
             {
-                joinButton.IsEnabled = false;
-            }
-        }
-
-        private void joinNetworkBox_OnKeyDown(object sender, KeyEventArgs e)
-        {
-            if (Keyboard.IsKeyDown(Key.LeftCtrl) || Keyboard.IsKeyDown(Key.RightCtrl))
-            {
-                if (e.Key == Key.X && joinNetworkBox.IsSelectionActive)
-                {
-                    // handle ctrl-x removing characters
-                    joinButton.IsEnabled = false;
-                }
-            }
-            else if (e.Key == Key.Delete || e.Key == Key.Back)
-            {
-                if ((joinNetworkBox.Text.Length - 1) == 16)
-                {
-                    joinButton.IsEnabled = true;
-                }
-                else
-                {
-                    joinButton.IsEnabled = false;
-                }
-            }
-            else
-            {
-                if ((joinNetworkBox.Text.Length + 1) > 16)
-                {
-                    e.Handled = true;
-                }
+                networkID = value;
+                JoinEnabled = networkID.Length == 16 && wholeStringRegex.IsMatch(networkID);
             }
         }
-
-        private void onPaste(object sender, DataObjectPastingEventArgs e)
-        {
-            var isText = e.SourceDataObject.GetDataPresent(DataFormats.UnicodeText, true);
-            if (!isText)
-            {
-                joinButton.IsEnabled = false;
-                return;
-            }
-
-            var text = e.SourceDataObject.GetData(DataFormats.UnicodeText) as string;
-
-            if (!wholeStringRegex.IsMatch(text))
-            {
-                e.Handled = true;
-                e.CancelCommand();
-            }
-
-            if (text.Length == 16 || (joinNetworkBox.Text.Length + text.Length) == 16)
-            {
-                joinButton.IsEnabled = true;
-            }
-            else if (text.Length > 16 || (joinNetworkBox.Text.Length + text.Length) > 16)
-            {
-                e.Handled = true;
-                e.CancelCommand();
-            }
-            else
-            {
-                joinButton.IsEnabled = false;
-            }
-        }
-
-        private void onCopyCut(object sender, DataObjectCopyingEventArgs e)
-        {
-            
-        }
+        public bool AllowDefault { get; set; } = false;
+        public bool AllowGlobal { get; set; } = false;
+        public bool AllowManaged { get; set; } = true;
+        public bool JoinEnabled { get; set; } = false;
 
         private void joinButton_Click(object sender, RoutedEventArgs e)
         {
-            bool allowDefault = allowDefaultCheckbox.IsChecked.Value;
-            bool allowGlobal = allowGlobalCheckbox.IsChecked.Value;
-            bool allowManaged = allowManagedCheckbox.IsChecked.Value;
-
-            APIHandler.Instance.JoinNetwork(this.Dispatcher, joinNetworkBox.Text, allowManaged, allowGlobal, allowDefault);
+            APIHandler.Instance.JoinNetwork(Dispatcher, joinNetworkBox.Text, AllowManaged, AllowGlobal, AllowDefault);
 
             Close();
         }

--- a/windows/WinUI/Properties/Resources.Designer.cs
+++ b/windows/WinUI/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace WinUI.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/windows/WinUI/Properties/Settings.Designer.cs
+++ b/windows/WinUI/Properties/Settings.Designer.cs
@@ -8,21 +8,17 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace WinUI.Properties
-{
-
-
+namespace WinUI.Properties {
+    
+    
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "11.0.0.0")]
-    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase
-    {
-
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.5.0.0")]
+    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
+        
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
-
-        public static Settings Default
-        {
-            get
-            {
+        
+        public static Settings Default {
+            get {
                 return defaultInstance;
             }
         }

--- a/windows/WinUI/WinUI.csproj
+++ b/windows/WinUI/WinUI.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WinUI</RootNamespace>
     <AssemblyName>ZeroTier One</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
@@ -30,6 +30,9 @@
     <ApplicationVersion>1.0.0.0</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -67,21 +70,29 @@
   <ItemGroup>
     <Reference Include="Accessibility" />
     <Reference Include="Hardcodet.Wpf.TaskbarNotification, Version=1.0.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Hardcodet.NotifyIcon.Wpf.1.0.8\lib\net45\Hardcodet.Wpf.TaskbarNotification.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Hardcodet.NotifyIcon.Wpf.1.0.8\lib\net451\Hardcodet.Wpf.TaskbarNotification.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="PresentationUI, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="PropertyChanged, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ee3ee20bcf148ddd, processorArchitecture=MSIL">
+      <HintPath>..\packages\PropertyChanged.Fody.2.2.5\lib\net452\PropertyChanged.dll</HintPath>
+    </Reference>
     <Reference Include="ReachFramework" />
+    <Reference Include="RestSharp, Version=106.2.1.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.106.2.1\lib\net452\RestSharp.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Deployment" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Printing" />
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
@@ -309,11 +320,21 @@
   <ItemGroup>
     <None Include="Resources\ZeroTierIcon.ico" />
   </ItemGroup>
+  <ItemGroup>
+    <Resource Include="FodyWeavers.xml" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\Expression\Blend\.NETFramework\v4.5\Microsoft.Expression.Blend.WPF.targets" />
+  <!--<Import Project="$(MSBuildExtensionsPath)\Microsoft\Expression\Blend\.NETFramework\v4.5\Microsoft.Expression.Blend.WPF.targets" />-->
   <PropertyGroup>
     <PostBuildEvent>copy "$(SolutionDir)\copyutil\bin\$(ConfigurationName)\copyutil.exe" "$(ProjectDir)\$(OutDir)\copyutil.exe"</PostBuildEvent>
   </PropertyGroup>
+  <Import Project="..\packages\Fody.2.3.20\build\Fody.targets" Condition="Exists('..\packages\Fody.2.3.20\build\Fody.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Fody.2.3.20\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.2.3.20\build\Fody.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/windows/WinUI/packages.config
+++ b/windows/WinUI/packages.config
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Hardcodet.NotifyIcon.Wpf" version="1.0.8" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="Fody" version="2.3.20" targetFramework="net452" developmentDependency="true" />
+  <package id="Hardcodet.NotifyIcon.Wpf" version="1.0.8" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
+  <package id="PropertyChanged.Fody" version="2.2.5" targetFramework="net452" />
+  <package id="RestSharp" version="106.2.1" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net452" />
 </packages>

--- a/windows/ZeroTierOne/ZeroTierOne.vcxproj
+++ b/windows/ZeroTierOne/ZeroTierOne.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -189,43 +189,44 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B00A4957-5977-4AC1-9EF4-571DC27EADA2}</ProjectGuid>
     <RootNamespace>ZeroTierOne</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Profile|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Profile|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>


### PR DESCRIPTION
Simplify JoinNetworkView
Update to .net 4.5.2 which "every" nuget in the world targets

Probably shouldn't have changed PlatformToolset and ToolsVersion in the project, I'm open for input.

The relevant changes are
JoinNetworkView.xaml
JoinNetworkView.xaml.cs
FodyWeavers.xml
packages.config

packages.config could probably have restsharp removed for now.

