### PR TITLE
check physical blacklist for interface binding as well

### DIFF
--- a/service/OneService.cpp
+++ b/service/OneService.cpp
@@ -2414,7 +2414,22 @@ public:
 					return false;
 			}
 		}
-
+		{
+			// Check global blacklists
+			const std::vector<InetAddress> *gbl = (const std::vector<InetAddress> *)0;
+			if (ifaddr.ss_family == AF_INET) {
+				gbl = &_globalV4Blacklist;
+			} else if (ifaddr.ss_family == AF_INET6) {
+				gbl = &_globalV6Blacklist;
+			}
+			if (gbl) {
+				Mutex::Lock _l(_localConfig_m);
+				for(std::vector<InetAddress>::const_iterator a(gbl->begin());a!=gbl->end();++a) {
+					if (a->containsAddress(ifaddr))
+						return false;
+				}
+			}
+		}
 		{
 			Mutex::Lock _l(_nets_m);
 			for(std::map<uint64_t,NetworkState>::const_iterator n(_nets.begin());n!=_nets.end();++n) {


### PR DESCRIPTION
This may relevant for https://github.com/zerotier/ZeroTierOne/issues/670

This applies local.conf physical blacklists to interface binds as well.