### PR TITLE
Fix ed25519-amd64-asm PIC compatibility

### DIFF
--- a/ext/ed25519-amd64-asm/fe25519_mul.s
+++ b/ext/ed25519-amd64-asm/fe25519_mul.s
@@ -652,7 +652,7 @@ adc %rdx,%r11
 mov  %r8,%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   mulr4 = mulrax
 # asm 1: mov  <mulrax=int64#7,>mulr4=int64#2
@@ -670,7 +670,7 @@ mov  %r9,%rax
 mov  %rdx,%rcx
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr5 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr5=int64#4
@@ -693,7 +693,7 @@ mov  $0,%r8
 adc %rdx,%r8
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr6 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr6=int64#5
@@ -716,7 +716,7 @@ mov  $0,%r9
 adc %rdx,%r9
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr7 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr7=int64#6

--- a/ext/ed25519-amd64-asm/fe25519_square.s
+++ b/ext/ed25519-amd64-asm/fe25519_square.s
@@ -426,7 +426,7 @@ adc %rdx,%rcx
 mov  %r11,%rax
 
 # qhasm:   (uint128) squarerdx squarerax = squarerax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   squarer4 = squarerax
 # asm 1: mov  <squarerax=int64#7,>squarer4=int64#2
@@ -444,7 +444,7 @@ mov  %r12,%rax
 mov  %rdx,%r11
 
 # qhasm:   (uint128) squarerdx squarerax = squarerax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? squarer5 += squarerax
 # asm 1: add  <squarerax=int64#7,<squarer5=int64#9
@@ -467,7 +467,7 @@ mov  $0,%r12
 adc %rdx,%r12
 
 # qhasm:   (uint128) squarerdx squarerax = squarerax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? squarer6 += squarerax
 # asm 1: add  <squarerax=int64#7,<squarer6=int64#10
@@ -490,7 +490,7 @@ mov  $0,%rcx
 adc %rdx,%rcx
 
 # qhasm:   (uint128) squarerdx squarerax = squarerax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? squarer7 += squarerax
 # asm 1: add  <squarerax=int64#7,<squarer7=int64#4

--- a/ext/ed25519-amd64-asm/ge25519_add_p1p1.s
+++ b/ext/ed25519-amd64-asm/ge25519_add_p1p1.s
@@ -1208,7 +1208,7 @@ adc %rdx,%r11
 mov  %r8,%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   mulr4 = mulrax
 # asm 1: mov  <mulrax=int64#7,>mulr4=int64#5
@@ -1226,7 +1226,7 @@ mov  %r9,%rax
 mov  %rdx,%r9
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr5 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr5=int64#6
@@ -1249,7 +1249,7 @@ mov  $0,%r10
 adc %rdx,%r10
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr6 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr6=int64#8
@@ -1272,7 +1272,7 @@ mov  $0,%r11
 adc %rdx,%r11
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr7 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr7=int64#9
@@ -1890,7 +1890,7 @@ adc %rdx,%r11
 mov  %r8,%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   mulr4 = mulrax
 # asm 1: mov  <mulrax=int64#7,>mulr4=int64#5
@@ -1908,7 +1908,7 @@ mov  %r9,%rax
 mov  %rdx,%r9
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr5 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr5=int64#6
@@ -1931,7 +1931,7 @@ mov  $0,%r10
 adc %rdx,%r10
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr6 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr6=int64#8
@@ -1954,7 +1954,7 @@ mov  $0,%r11
 adc %rdx,%r11
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr7 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr7=int64#9
@@ -2742,7 +2742,7 @@ adc %rdx,%r11
 mov  %r8,%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   mulr4 = mulrax
 # asm 1: mov  <mulrax=int64#7,>mulr4=int64#5
@@ -2760,7 +2760,7 @@ mov  %r9,%rax
 mov  %rdx,%r9
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr5 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr5=int64#6
@@ -2783,7 +2783,7 @@ mov  $0,%r10
 adc %rdx,%r10
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr6 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr6=int64#8
@@ -2806,7 +2806,7 @@ mov  $0,%r11
 adc %rdx,%r11
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr7 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr7=int64#9
@@ -2941,7 +2941,7 @@ movq 56(%rsp),%r12
 # qhasm:   mulrax = *(uint64 *)&crypto_sign_ed25519_amd64_64_EC2D0
 # asm 1: movq crypto_sign_ed25519_amd64_64_EC2D0,>mulrax=int64#7
 # asm 2: movq crypto_sign_ed25519_amd64_64_EC2D0,>mulrax=%rax
-movq crypto_sign_ed25519_amd64_64_EC2D0,%rax
+movq crypto_sign_ed25519_amd64_64_EC2D0(%rip),%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * mulx0
 # asm 1: mul  <mulx0=int64#10
@@ -2961,7 +2961,7 @@ mov  %rdx,%r14
 # qhasm:   mulrax = *(uint64 *)&crypto_sign_ed25519_amd64_64_EC2D1
 # asm 1: movq crypto_sign_ed25519_amd64_64_EC2D1,>mulrax=int64#7
 # asm 2: movq crypto_sign_ed25519_amd64_64_EC2D1,>mulrax=%rax
-movq crypto_sign_ed25519_amd64_64_EC2D1,%rax
+movq crypto_sign_ed25519_amd64_64_EC2D1(%rip),%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * mulx0
 # asm 1: mul  <mulx0=int64#10
@@ -2986,7 +2986,7 @@ adc %rdx,%r15
 # qhasm:   mulrax = *(uint64 *)&crypto_sign_ed25519_amd64_64_EC2D2
 # asm 1: movq crypto_sign_ed25519_amd64_64_EC2D2,>mulrax=int64#7
 # asm 2: movq crypto_sign_ed25519_amd64_64_EC2D2,>mulrax=%rax
-movq crypto_sign_ed25519_amd64_64_EC2D2,%rax
+movq crypto_sign_ed25519_amd64_64_EC2D2(%rip),%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * mulx0
 # asm 1: mul  <mulx0=int64#10
@@ -3011,7 +3011,7 @@ adc %rdx,%rbx
 # qhasm:   mulrax = *(uint64 *)&crypto_sign_ed25519_amd64_64_EC2D3
 # asm 1: movq crypto_sign_ed25519_amd64_64_EC2D3,>mulrax=int64#7
 # asm 2: movq crypto_sign_ed25519_amd64_64_EC2D3,>mulrax=%rax
-movq crypto_sign_ed25519_amd64_64_EC2D3,%rax
+movq crypto_sign_ed25519_amd64_64_EC2D3(%rip),%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * mulx0
 # asm 1: mul  <mulx0=int64#10
@@ -3036,7 +3036,7 @@ movq 64(%rsp),%r12
 # qhasm:   mulrax = *(uint64 *)&crypto_sign_ed25519_amd64_64_EC2D0
 # asm 1: movq crypto_sign_ed25519_amd64_64_EC2D0,>mulrax=int64#7
 # asm 2: movq crypto_sign_ed25519_amd64_64_EC2D0,>mulrax=%rax
-movq crypto_sign_ed25519_amd64_64_EC2D0,%rax
+movq crypto_sign_ed25519_amd64_64_EC2D0(%rip),%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * mulx1
 # asm 1: mul  <mulx1=int64#10
@@ -3061,7 +3061,7 @@ adc %rdx,%rbp
 # qhasm:   mulrax = *(uint64 *)&crypto_sign_ed25519_amd64_64_EC2D1
 # asm 1: movq crypto_sign_ed25519_amd64_64_EC2D1,>mulrax=int64#7
 # asm 2: movq crypto_sign_ed25519_amd64_64_EC2D1,>mulrax=%rax
-movq crypto_sign_ed25519_amd64_64_EC2D1,%rax
+movq crypto_sign_ed25519_amd64_64_EC2D1(%rip),%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * mulx1
 # asm 1: mul  <mulx1=int64#10
@@ -3096,7 +3096,7 @@ adc %rdx,%rbp
 # qhasm:   mulrax = *(uint64 *)&crypto_sign_ed25519_amd64_64_EC2D2
 # asm 1: movq crypto_sign_ed25519_amd64_64_EC2D2,>mulrax=int64#7
 # asm 2: movq crypto_sign_ed25519_amd64_64_EC2D2,>mulrax=%rax
-movq crypto_sign_ed25519_amd64_64_EC2D2,%rax
+movq crypto_sign_ed25519_amd64_64_EC2D2(%rip),%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * mulx1
 # asm 1: mul  <mulx1=int64#10
@@ -3131,7 +3131,7 @@ adc %rdx,%rbp
 # qhasm:   mulrax = *(uint64 *)&crypto_sign_ed25519_amd64_64_EC2D3
 # asm 1: movq crypto_sign_ed25519_amd64_64_EC2D3,>mulrax=int64#7
 # asm 2: movq crypto_sign_ed25519_amd64_64_EC2D3,>mulrax=%rax
-movq crypto_sign_ed25519_amd64_64_EC2D3,%rax
+movq crypto_sign_ed25519_amd64_64_EC2D3(%rip),%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * mulx1
 # asm 1: mul  <mulx1=int64#10
@@ -3166,7 +3166,7 @@ movq 72(%rsp),%r12
 # qhasm:   mulrax = *(uint64 *)&crypto_sign_ed25519_amd64_64_EC2D0
 # asm 1: movq crypto_sign_ed25519_amd64_64_EC2D0,>mulrax=int64#7
 # asm 2: movq crypto_sign_ed25519_amd64_64_EC2D0,>mulrax=%rax
-movq crypto_sign_ed25519_amd64_64_EC2D0,%rax
+movq crypto_sign_ed25519_amd64_64_EC2D0(%rip),%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * mulx2
 # asm 1: mul  <mulx2=int64#10
@@ -3191,7 +3191,7 @@ adc %rdx,%rbp
 # qhasm:   mulrax = *(uint64 *)&crypto_sign_ed25519_amd64_64_EC2D1
 # asm 1: movq crypto_sign_ed25519_amd64_64_EC2D1,>mulrax=int64#7
 # asm 2: movq crypto_sign_ed25519_amd64_64_EC2D1,>mulrax=%rax
-movq crypto_sign_ed25519_amd64_64_EC2D1,%rax
+movq crypto_sign_ed25519_amd64_64_EC2D1(%rip),%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * mulx2
 # asm 1: mul  <mulx2=int64#10
@@ -3226,7 +3226,7 @@ adc %rdx,%rbp
 # qhasm:   mulrax = *(uint64 *)&crypto_sign_ed25519_amd64_64_EC2D2
 # asm 1: movq crypto_sign_ed25519_amd64_64_EC2D2,>mulrax=int64#7
 # asm 2: movq crypto_sign_ed25519_amd64_64_EC2D2,>mulrax=%rax
-movq crypto_sign_ed25519_amd64_64_EC2D2,%rax
+movq crypto_sign_ed25519_amd64_64_EC2D2(%rip),%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * mulx2
 # asm 1: mul  <mulx2=int64#10
@@ -3261,7 +3261,7 @@ adc %rdx,%rbp
 # qhasm:   mulrax = *(uint64 *)&crypto_sign_ed25519_amd64_64_EC2D3
 # asm 1: movq crypto_sign_ed25519_amd64_64_EC2D3,>mulrax=int64#7
 # asm 2: movq crypto_sign_ed25519_amd64_64_EC2D3,>mulrax=%rax
-movq crypto_sign_ed25519_amd64_64_EC2D3,%rax
+movq crypto_sign_ed25519_amd64_64_EC2D3(%rip),%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * mulx2
 # asm 1: mul  <mulx2=int64#10
@@ -3296,7 +3296,7 @@ movq 80(%rsp),%r12
 # qhasm:   mulrax = *(uint64 *)&crypto_sign_ed25519_amd64_64_EC2D0
 # asm 1: movq crypto_sign_ed25519_amd64_64_EC2D0,>mulrax=int64#7
 # asm 2: movq crypto_sign_ed25519_amd64_64_EC2D0,>mulrax=%rax
-movq crypto_sign_ed25519_amd64_64_EC2D0,%rax
+movq crypto_sign_ed25519_amd64_64_EC2D0(%rip),%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * mulx3
 # asm 1: mul  <mulx3=int64#10
@@ -3321,7 +3321,7 @@ adc %rdx,%rbp
 # qhasm:   mulrax = *(uint64 *)&crypto_sign_ed25519_amd64_64_EC2D1
 # asm 1: movq crypto_sign_ed25519_amd64_64_EC2D1,>mulrax=int64#7
 # asm 2: movq crypto_sign_ed25519_amd64_64_EC2D1,>mulrax=%rax
-movq crypto_sign_ed25519_amd64_64_EC2D1,%rax
+movq crypto_sign_ed25519_amd64_64_EC2D1(%rip),%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * mulx3
 # asm 1: mul  <mulx3=int64#10
@@ -3356,7 +3356,7 @@ adc %rdx,%rbp
 # qhasm:   mulrax = *(uint64 *)&crypto_sign_ed25519_amd64_64_EC2D2
 # asm 1: movq crypto_sign_ed25519_amd64_64_EC2D2,>mulrax=int64#7
 # asm 2: movq crypto_sign_ed25519_amd64_64_EC2D2,>mulrax=%rax
-movq crypto_sign_ed25519_amd64_64_EC2D2,%rax
+movq crypto_sign_ed25519_amd64_64_EC2D2(%rip),%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * mulx3
 # asm 1: mul  <mulx3=int64#10
@@ -3391,7 +3391,7 @@ adc %rdx,%rbp
 # qhasm:   mulrax = *(uint64 *)&crypto_sign_ed25519_amd64_64_EC2D3
 # asm 1: movq crypto_sign_ed25519_amd64_64_EC2D3,>mulrax=int64#7
 # asm 2: movq crypto_sign_ed25519_amd64_64_EC2D3,>mulrax=%rax
-movq crypto_sign_ed25519_amd64_64_EC2D3,%rax
+movq crypto_sign_ed25519_amd64_64_EC2D3(%rip),%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * mulx3
 # asm 1: mul  <mulx3=int64#10
@@ -3424,7 +3424,7 @@ adc %rdx,%r11
 mov  %r8,%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   mulr4 = mulrax
 # asm 1: mov  <mulrax=int64#7,>mulr4=int64#5
@@ -3442,7 +3442,7 @@ mov  %r9,%rax
 mov  %rdx,%r9
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr5 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr5=int64#6
@@ -3465,7 +3465,7 @@ mov  $0,%r10
 adc %rdx,%r10
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr6 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr6=int64#8
@@ -3488,7 +3488,7 @@ mov  $0,%r11
 adc %rdx,%r11
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr7 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr7=int64#9
@@ -4106,7 +4106,7 @@ adc %rdx,%r11
 mov  %r8,%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   mulr4 = mulrax
 # asm 1: mov  <mulrax=int64#7,>mulr4=int64#2
@@ -4124,7 +4124,7 @@ mov  %r9,%rax
 mov  %rdx,%rcx
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr5 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr5=int64#4
@@ -4147,7 +4147,7 @@ mov  $0,%r8
 adc %rdx,%r8
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr6 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr6=int64#5
@@ -4170,7 +4170,7 @@ mov  $0,%r9
 adc %rdx,%r9
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr7 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr7=int64#6

--- a/ext/ed25519-amd64-asm/ge25519_dbl_p1p1.s
+++ b/ext/ed25519-amd64-asm/ge25519_dbl_p1p1.s
@@ -576,7 +576,7 @@ adc %rdx,%rcx
 mov  %r11,%rax
 
 # qhasm:   (uint128) squarerdx squarerax = squarerax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   squarer4 = squarerax
 # asm 1: mov  <squarerax=int64#7,>squarer4=int64#9
@@ -594,7 +594,7 @@ mov  %r12,%rax
 mov  %rdx,%r12
 
 # qhasm:   (uint128) squarerdx squarerax = squarerax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? squarer5 += squarerax
 # asm 1: add  <squarerax=int64#7,<squarer5=int64#10
@@ -617,7 +617,7 @@ mov  $0,%r13
 adc %rdx,%r13
 
 # qhasm:   (uint128) squarerdx squarerax = squarerax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? squarer6 += squarerax
 # asm 1: add  <squarerax=int64#7,<squarer6=int64#11
@@ -640,7 +640,7 @@ mov  $0,%rcx
 adc %rdx,%rcx
 
 # qhasm:   (uint128) squarerdx squarerax = squarerax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? squarer7 += squarerax
 # asm 1: add  <squarerax=int64#7,<squarer7=int64#4
@@ -1043,7 +1043,7 @@ adc %rdx,%rcx
 mov  %r11,%rax
 
 # qhasm:   (uint128) squarerdx squarerax = squarerax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   squarer4 = squarerax
 # asm 1: mov  <squarerax=int64#7,>squarer4=int64#9
@@ -1061,7 +1061,7 @@ mov  %r12,%rax
 mov  %rdx,%r12
 
 # qhasm:   (uint128) squarerdx squarerax = squarerax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? squarer5 += squarerax
 # asm 1: add  <squarerax=int64#7,<squarer5=int64#10
@@ -1084,7 +1084,7 @@ mov  $0,%r13
 adc %rdx,%r13
 
 # qhasm:   (uint128) squarerdx squarerax = squarerax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? squarer6 += squarerax
 # asm 1: add  <squarerax=int64#7,<squarer6=int64#11
@@ -1107,7 +1107,7 @@ mov  $0,%rcx
 adc %rdx,%rcx
 
 # qhasm:   (uint128) squarerdx squarerax = squarerax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? squarer7 += squarerax
 # asm 1: add  <squarerax=int64#7,<squarer7=int64#4
@@ -1510,7 +1510,7 @@ adc %rdx,%rcx
 mov  %r11,%rax
 
 # qhasm:   (uint128) squarerdx squarerax = squarerax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   squarer4 = squarerax
 # asm 1: mov  <squarerax=int64#7,>squarer4=int64#9
@@ -1528,7 +1528,7 @@ mov  %r12,%rax
 mov  %rdx,%r12
 
 # qhasm:   (uint128) squarerdx squarerax = squarerax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? squarer5 += squarerax
 # asm 1: add  <squarerax=int64#7,<squarer5=int64#10
@@ -1551,7 +1551,7 @@ mov  $0,%r13
 adc %rdx,%r13
 
 # qhasm:   (uint128) squarerdx squarerax = squarerax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? squarer6 += squarerax
 # asm 1: add  <squarerax=int64#7,<squarer6=int64#11
@@ -1574,7 +1574,7 @@ mov  $0,%rcx
 adc %rdx,%rcx
 
 # qhasm:   (uint128) squarerdx squarerax = squarerax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? squarer7 += squarerax
 # asm 1: add  <squarerax=int64#7,<squarer7=int64#4
@@ -2632,7 +2632,7 @@ adc %rdx,%rsi
 mov  %r10,%rax
 
 # qhasm:   (uint128) squarerdx squarerax = squarerax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   squarer4 = squarerax
 # asm 1: mov  <squarerax=int64#7,>squarer4=int64#8
@@ -2650,7 +2650,7 @@ mov  %r11,%rax
 mov  %rdx,%r11
 
 # qhasm:   (uint128) squarerdx squarerax = squarerax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? squarer5 += squarerax
 # asm 1: add  <squarerax=int64#7,<squarer5=int64#9
@@ -2673,7 +2673,7 @@ mov  $0,%r12
 adc %rdx,%r12
 
 # qhasm:   (uint128) squarerdx squarerax = squarerax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? squarer6 += squarerax
 # asm 1: add  <squarerax=int64#7,<squarer6=int64#10
@@ -2696,7 +2696,7 @@ mov  $0,%rsi
 adc %rdx,%rsi
 
 # qhasm:   (uint128) squarerdx squarerax = squarerax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? squarer7 += squarerax
 # asm 1: add  <squarerax=int64#7,<squarer7=int64#2

--- a/ext/ed25519-amd64-asm/ge25519_nielsadd2.s
+++ b/ext/ed25519-amd64-asm/ge25519_nielsadd2.s
@@ -1061,7 +1061,7 @@ adc %rdx,%r10
 mov  %rcx,%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   mulr4 = mulrax
 # asm 1: mov  <mulrax=int64#7,>mulr4=int64#4
@@ -1079,7 +1079,7 @@ mov  %r8,%rax
 mov  %rdx,%r8
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr5 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr5=int64#5
@@ -1102,7 +1102,7 @@ mov  $0,%r9
 adc %rdx,%r9
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr6 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr6=int64#6
@@ -1125,7 +1125,7 @@ mov  $0,%r10
 adc %rdx,%r10
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr7 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr7=int64#8
@@ -1743,7 +1743,7 @@ adc %rdx,%r10
 mov  %rcx,%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   mulr4 = mulrax
 # asm 1: mov  <mulrax=int64#7,>mulr4=int64#4
@@ -1761,7 +1761,7 @@ mov  %r8,%rax
 mov  %rdx,%r8
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr5 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr5=int64#5
@@ -1784,7 +1784,7 @@ mov  $0,%r9
 adc %rdx,%r9
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr6 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr6=int64#6
@@ -1807,7 +1807,7 @@ mov  $0,%r10
 adc %rdx,%r10
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr7 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr7=int64#8
@@ -2595,7 +2595,7 @@ adc %rdx,%r10
 mov  %rcx,%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   mulr4 = mulrax
 # asm 1: mov  <mulrax=int64#7,>mulr4=int64#2
@@ -2613,7 +2613,7 @@ mov  %r8,%rax
 mov  %rdx,%rcx
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr5 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr5=int64#4
@@ -2636,7 +2636,7 @@ mov  $0,%r8
 adc %rdx,%r8
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr6 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr6=int64#5
@@ -2659,7 +2659,7 @@ mov  $0,%r9
 adc %rdx,%r9
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr7 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr7=int64#6
@@ -3532,7 +3532,7 @@ adc %rdx,%r9
 mov  %rsi,%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   mulr4 = mulrax
 # asm 1: mov  <mulrax=int64#7,>mulr4=int64#2
@@ -3550,7 +3550,7 @@ mov  %rcx,%rax
 mov  %rdx,%rcx
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr5 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr5=int64#4
@@ -3573,7 +3573,7 @@ mov  $0,%r8
 adc %rdx,%r8
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr6 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr6=int64#5
@@ -3596,7 +3596,7 @@ mov  $0,%r9
 adc %rdx,%r9
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr7 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr7=int64#6
@@ -4214,7 +4214,7 @@ adc %rdx,%r9
 mov  %rsi,%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   mulr4 = mulrax
 # asm 1: mov  <mulrax=int64#7,>mulr4=int64#2
@@ -4232,7 +4232,7 @@ mov  %rcx,%rax
 mov  %rdx,%rcx
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr5 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr5=int64#4
@@ -4255,7 +4255,7 @@ mov  $0,%r8
 adc %rdx,%r8
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr6 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr6=int64#5
@@ -4278,7 +4278,7 @@ mov  $0,%r9
 adc %rdx,%r9
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr7 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr7=int64#6
@@ -4896,7 +4896,7 @@ adc %rdx,%r9
 mov  %rsi,%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   mulr4 = mulrax
 # asm 1: mov  <mulrax=int64#7,>mulr4=int64#2
@@ -4914,7 +4914,7 @@ mov  %rcx,%rax
 mov  %rdx,%rcx
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr5 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr5=int64#4
@@ -4937,7 +4937,7 @@ mov  $0,%r8
 adc %rdx,%r8
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr6 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr6=int64#5
@@ -4960,7 +4960,7 @@ mov  $0,%r9
 adc %rdx,%r9
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr7 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr7=int64#6
@@ -5578,7 +5578,7 @@ adc %rdx,%r9
 mov  %rsi,%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   mulr4 = mulrax
 # asm 1: mov  <mulrax=int64#7,>mulr4=int64#2
@@ -5596,7 +5596,7 @@ mov  %rcx,%rax
 mov  %rdx,%rcx
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr5 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr5=int64#4
@@ -5619,7 +5619,7 @@ mov  $0,%r8
 adc %rdx,%r8
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr6 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr6=int64#5
@@ -5642,7 +5642,7 @@ mov  $0,%r9
 adc %rdx,%r9
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr7 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr7=int64#6

--- a/ext/ed25519-amd64-asm/ge25519_nielsadd_p1p1.s
+++ b/ext/ed25519-amd64-asm/ge25519_nielsadd_p1p1.s
@@ -1070,7 +1070,7 @@ adc %rdx,%r11
 mov  %r8,%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   mulr4 = mulrax
 # asm 1: mov  <mulrax=int64#7,>mulr4=int64#5
@@ -1088,7 +1088,7 @@ mov  %r9,%rax
 mov  %rdx,%r9
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr5 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr5=int64#6
@@ -1111,7 +1111,7 @@ mov  $0,%r10
 adc %rdx,%r10
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr6 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr6=int64#8
@@ -1134,7 +1134,7 @@ mov  $0,%r11
 adc %rdx,%r11
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr7 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr7=int64#9
@@ -1752,7 +1752,7 @@ adc %rdx,%r11
 mov  %r8,%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   mulr4 = mulrax
 # asm 1: mov  <mulrax=int64#7,>mulr4=int64#5
@@ -1770,7 +1770,7 @@ mov  %r9,%rax
 mov  %rdx,%r9
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr5 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr5=int64#6
@@ -1793,7 +1793,7 @@ mov  $0,%r10
 adc %rdx,%r10
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr6 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr6=int64#8
@@ -1816,7 +1816,7 @@ mov  $0,%r11
 adc %rdx,%r11
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr7 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr7=int64#9
@@ -2604,7 +2604,7 @@ adc %rdx,%r11
 mov  %r8,%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   mulr4 = mulrax
 # asm 1: mov  <mulrax=int64#7,>mulr4=int64#4
@@ -2622,7 +2622,7 @@ mov  %r9,%rax
 mov  %rdx,%r8
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr5 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr5=int64#5
@@ -2645,7 +2645,7 @@ mov  $0,%r9
 adc %rdx,%r9
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr6 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr6=int64#6
@@ -2668,7 +2668,7 @@ mov  $0,%r10
 adc %rdx,%r10
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr7 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr7=int64#8

--- a/ext/ed25519-amd64-asm/ge25519_p1p1_to_p2.s
+++ b/ext/ed25519-amd64-asm/ge25519_p1p1_to_p2.s
@@ -659,7 +659,7 @@ adc %rdx,%r10
 mov  %rcx,%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   mulr4 = mulrax
 # asm 1: mov  <mulrax=int64#7,>mulr4=int64#4
@@ -677,7 +677,7 @@ mov  %r8,%rax
 mov  %rdx,%r8
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr5 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr5=int64#5
@@ -700,7 +700,7 @@ mov  $0,%r9
 adc %rdx,%r9
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr6 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr6=int64#6
@@ -723,7 +723,7 @@ mov  $0,%r10
 adc %rdx,%r10
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr7 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr7=int64#8
@@ -1341,7 +1341,7 @@ adc %rdx,%r10
 mov  %rcx,%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   mulr4 = mulrax
 # asm 1: mov  <mulrax=int64#7,>mulr4=int64#4
@@ -1359,7 +1359,7 @@ mov  %r8,%rax
 mov  %rdx,%r8
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr5 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr5=int64#5
@@ -1382,7 +1382,7 @@ mov  $0,%r9
 adc %rdx,%r9
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr6 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr6=int64#6
@@ -1405,7 +1405,7 @@ mov  $0,%r10
 adc %rdx,%r10
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr7 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr7=int64#8
@@ -2023,7 +2023,7 @@ adc %rdx,%r10
 mov  %rcx,%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   mulr4 = mulrax
 # asm 1: mov  <mulrax=int64#7,>mulr4=int64#2
@@ -2041,7 +2041,7 @@ mov  %r8,%rax
 mov  %rdx,%rcx
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr5 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr5=int64#4
@@ -2064,7 +2064,7 @@ mov  $0,%r8
 adc %rdx,%r8
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr6 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr6=int64#5
@@ -2087,7 +2087,7 @@ mov  $0,%r9
 adc %rdx,%r9
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr7 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr7=int64#6

--- a/ext/ed25519-amd64-asm/ge25519_p1p1_to_p3.s
+++ b/ext/ed25519-amd64-asm/ge25519_p1p1_to_p3.s
@@ -667,7 +667,7 @@ adc %rdx,%r10
 mov  %rcx,%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   mulr4 = mulrax
 # asm 1: mov  <mulrax=int64#7,>mulr4=int64#4
@@ -685,7 +685,7 @@ mov  %r8,%rax
 mov  %rdx,%r8
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr5 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr5=int64#5
@@ -708,7 +708,7 @@ mov  $0,%r9
 adc %rdx,%r9
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr6 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr6=int64#6
@@ -731,7 +731,7 @@ mov  $0,%r10
 adc %rdx,%r10
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr7 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr7=int64#8
@@ -1349,7 +1349,7 @@ adc %rdx,%r10
 mov  %rcx,%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   mulr4 = mulrax
 # asm 1: mov  <mulrax=int64#7,>mulr4=int64#4
@@ -1367,7 +1367,7 @@ mov  %r8,%rax
 mov  %rdx,%r8
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr5 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr5=int64#5
@@ -1390,7 +1390,7 @@ mov  $0,%r9
 adc %rdx,%r9
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr6 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr6=int64#6
@@ -1413,7 +1413,7 @@ mov  $0,%r10
 adc %rdx,%r10
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr7 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr7=int64#8
@@ -2031,7 +2031,7 @@ adc %rdx,%r10
 mov  %rcx,%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   mulr4 = mulrax
 # asm 1: mov  <mulrax=int64#7,>mulr4=int64#4
@@ -2049,7 +2049,7 @@ mov  %r8,%rax
 mov  %rdx,%r8
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr5 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr5=int64#5
@@ -2072,7 +2072,7 @@ mov  $0,%r9
 adc %rdx,%r9
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr6 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr6=int64#6
@@ -2095,7 +2095,7 @@ mov  $0,%r10
 adc %rdx,%r10
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr7 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr7=int64#8
@@ -2713,7 +2713,7 @@ adc %rdx,%r10
 mov  %rcx,%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   mulr4 = mulrax
 # asm 1: mov  <mulrax=int64#7,>mulr4=int64#2
@@ -2731,7 +2731,7 @@ mov  %r8,%rax
 mov  %rdx,%rcx
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr5 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr5=int64#4
@@ -2754,7 +2754,7 @@ mov  $0,%r8
 adc %rdx,%r8
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr6 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr6=int64#5
@@ -2777,7 +2777,7 @@ mov  $0,%r9
 adc %rdx,%r9
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr7 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr7=int64#6

--- a/ext/ed25519-amd64-asm/ge25519_pnielsadd_p1p1.s
+++ b/ext/ed25519-amd64-asm/ge25519_pnielsadd_p1p1.s
@@ -998,7 +998,7 @@ adc %rdx,%r11
 mov  %r8,%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   mulr4 = mulrax
 # asm 1: mov  <mulrax=int64#7,>mulr4=int64#5
@@ -1016,7 +1016,7 @@ mov  %r9,%rax
 mov  %rdx,%r9
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr5 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr5=int64#6
@@ -1039,7 +1039,7 @@ mov  $0,%r10
 adc %rdx,%r10
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr6 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr6=int64#8
@@ -1062,7 +1062,7 @@ mov  $0,%r11
 adc %rdx,%r11
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr7 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr7=int64#9
@@ -1680,7 +1680,7 @@ adc %rdx,%r11
 mov  %r8,%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   mulr4 = mulrax
 # asm 1: mov  <mulrax=int64#7,>mulr4=int64#5
@@ -1698,7 +1698,7 @@ mov  %r9,%rax
 mov  %rdx,%r9
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr5 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr5=int64#6
@@ -1721,7 +1721,7 @@ mov  $0,%r10
 adc %rdx,%r10
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr6 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr6=int64#8
@@ -1744,7 +1744,7 @@ mov  $0,%r11
 adc %rdx,%r11
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr7 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr7=int64#9
@@ -2532,7 +2532,7 @@ adc %rdx,%r11
 mov  %r8,%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   mulr4 = mulrax
 # asm 1: mov  <mulrax=int64#7,>mulr4=int64#5
@@ -2550,7 +2550,7 @@ mov  %r9,%rax
 mov  %rdx,%r9
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr5 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr5=int64#6
@@ -2573,7 +2573,7 @@ mov  $0,%r10
 adc %rdx,%r10
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr6 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr6=int64#8
@@ -2596,7 +2596,7 @@ mov  $0,%r11
 adc %rdx,%r11
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr7 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr7=int64#9
@@ -3214,7 +3214,7 @@ adc %rdx,%r11
 mov  %r8,%rax
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   mulr4 = mulrax
 # asm 1: mov  <mulrax=int64#7,>mulr4=int64#2
@@ -3232,7 +3232,7 @@ mov  %r9,%rax
 mov  %rdx,%rcx
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr5 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr5=int64#4
@@ -3255,7 +3255,7 @@ mov  $0,%r8
 adc %rdx,%r8
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr6 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr6=int64#5
@@ -3278,7 +3278,7 @@ mov  $0,%r9
 adc %rdx,%r9
 
 # qhasm:   (uint128) mulrdx mulrax = mulrax * *(uint64 *)&crypto_sign_ed25519_amd64_64_38
-mulq  crypto_sign_ed25519_amd64_64_38
+mulq  crypto_sign_ed25519_amd64_64_38(%rip)
 
 # qhasm:   carry? mulr7 += mulrax
 # asm 1: add  <mulrax=int64#7,<mulr7=int64#6

--- a/ext/ed25519-amd64-asm/sc25519_add.s
+++ b/ext/ed25519-amd64-asm/sc25519_add.s
@@ -153,22 +153,22 @@ mov  %rsi,%r14
 # qhasm: carry? t0 -= *(uint64 *) &crypto_sign_ed25519_amd64_64_ORDER0
 # asm 1: sub  crypto_sign_ed25519_amd64_64_ORDER0,<t0=int64#3
 # asm 2: sub  crypto_sign_ed25519_amd64_64_ORDER0,<t0=%rdx
-sub  crypto_sign_ed25519_amd64_64_ORDER0,%rdx
+sub  crypto_sign_ed25519_amd64_64_ORDER0(%rip),%rdx
 
 # qhasm: carry? t1 -= *(uint64 *) &crypto_sign_ed25519_amd64_64_ORDER1 - carry
 # asm 1: sbb  crypto_sign_ed25519_amd64_64_ORDER1,<t1=int64#7
 # asm 2: sbb  crypto_sign_ed25519_amd64_64_ORDER1,<t1=%rax
-sbb  crypto_sign_ed25519_amd64_64_ORDER1,%rax
+sbb  crypto_sign_ed25519_amd64_64_ORDER1(%rip),%rax
 
 # qhasm: carry? t2 -= *(uint64 *) &crypto_sign_ed25519_amd64_64_ORDER2 - carry
 # asm 1: sbb  crypto_sign_ed25519_amd64_64_ORDER2,<t2=int64#8
 # asm 2: sbb  crypto_sign_ed25519_amd64_64_ORDER2,<t2=%r10
-sbb  crypto_sign_ed25519_amd64_64_ORDER2,%r10
+sbb  crypto_sign_ed25519_amd64_64_ORDER2(%rip),%r10
 
 # qhasm: unsigned<? t3 -= *(uint64 *) &crypto_sign_ed25519_amd64_64_ORDER3 - carry
 # asm 1: sbb  crypto_sign_ed25519_amd64_64_ORDER3,<t3=int64#12
 # asm 2: sbb  crypto_sign_ed25519_amd64_64_ORDER3,<t3=%r14
-sbb  crypto_sign_ed25519_amd64_64_ORDER3,%r14
+sbb  crypto_sign_ed25519_amd64_64_ORDER3(%rip),%r14
 
 # qhasm: r0 = t0 if !unsigned<
 # asm 1: cmovae <t0=int64#3,<r0=int64#4

--- a/ext/ed25519-amd64-asm/sc25519_barrett.s
+++ b/ext/ed25519-amd64-asm/sc25519_barrett.s
@@ -185,7 +185,7 @@ xor  %r11,%r11
 movq   24(%rsi),%rax
 
 # qhasm: (uint128) rdx rax = rax * *(uint64 *) &crypto_sign_ed25519_amd64_64_MU3
-mulq  crypto_sign_ed25519_amd64_64_MU3
+mulq  crypto_sign_ed25519_amd64_64_MU3(%rip)
 
 # qhasm: q23 = rax
 # asm 1: mov  <rax=int64#7,>q23=int64#10
@@ -203,7 +203,7 @@ mov  %rdx,%r13
 movq   24(%rsi),%rax
 
 # qhasm: (uint128) rdx rax = rax * *(uint64 *) &crypto_sign_ed25519_amd64_64_MU4
-mulq  crypto_sign_ed25519_amd64_64_MU4
+mulq  crypto_sign_ed25519_amd64_64_MU4(%rip)
 
 # qhasm: q24 = rax
 # asm 1: mov  <rax=int64#7,>q24=int64#12
@@ -226,7 +226,7 @@ adc %rdx,%r8
 movq   32(%rsi),%rax
 
 # qhasm: (uint128) rdx rax = rax * *(uint64 *) &crypto_sign_ed25519_amd64_64_MU2
-mulq  crypto_sign_ed25519_amd64_64_MU2
+mulq  crypto_sign_ed25519_amd64_64_MU2(%rip)
 
 # qhasm: carry? q23 += rax
 # asm 1: add  <rax=int64#7,<q23=int64#10
@@ -249,7 +249,7 @@ adc %rdx,%r13
 movq   32(%rsi),%rax
 
 # qhasm: (uint128) rdx rax = rax * *(uint64 *) &crypto_sign_ed25519_amd64_64_MU3
-mulq  crypto_sign_ed25519_amd64_64_MU3
+mulq  crypto_sign_ed25519_amd64_64_MU3(%rip)
 
 # qhasm: carry? q24 += rax
 # asm 1: add  <rax=int64#7,<q24=int64#12
@@ -282,7 +282,7 @@ adc %rdx,%r13
 movq   32(%rsi),%rax
 
 # qhasm: (uint128) rdx rax = rax * *(uint64 *) &crypto_sign_ed25519_amd64_64_MU4
-mulq  crypto_sign_ed25519_amd64_64_MU4
+mulq  crypto_sign_ed25519_amd64_64_MU4(%rip)
 
 # qhasm: carry? q30 += rax 
 # asm 1: add  <rax=int64#7,<q30=int64#5
@@ -310,7 +310,7 @@ adc %rdx,%r9
 movq   40(%rsi),%rax
 
 # qhasm: (uint128) rdx rax = rax * *(uint64 *) &crypto_sign_ed25519_amd64_64_MU1
-mulq  crypto_sign_ed25519_amd64_64_MU1
+mulq  crypto_sign_ed25519_amd64_64_MU1(%rip)
 
 # qhasm: carry? q23 += rax
 # asm 1: add  <rax=int64#7,<q23=int64#10
@@ -333,7 +333,7 @@ adc %rdx,%r13
 movq   40(%rsi),%rax
 
 # qhasm: (uint128) rdx rax = rax * *(uint64 *) &crypto_sign_ed25519_amd64_64_MU2
-mulq  crypto_sign_ed25519_amd64_64_MU2
+mulq  crypto_sign_ed25519_amd64_64_MU2(%rip)
 
 # qhasm: carry? q24 += rax
 # asm 1: add  <rax=int64#7,<q24=int64#12
@@ -366,7 +366,7 @@ adc %rdx,%r13
 movq   40(%rsi),%rax
 
 # qhasm: (uint128) rdx rax = rax * *(uint64 *) &crypto_sign_ed25519_amd64_64_MU3
-mulq  crypto_sign_ed25519_amd64_64_MU3
+mulq  crypto_sign_ed25519_amd64_64_MU3(%rip)
 
 # qhasm: carry? q30 += rax
 # asm 1: add  <rax=int64#7,<q30=int64#5
@@ -399,7 +399,7 @@ adc %rdx,%r13
 movq   40(%rsi),%rax
 
 # qhasm: (uint128) rdx rax = rax * *(uint64 *) &crypto_sign_ed25519_amd64_64_MU4
-mulq  crypto_sign_ed25519_amd64_64_MU4
+mulq  crypto_sign_ed25519_amd64_64_MU4(%rip)
 
 # qhasm: carry? q31 += rax 
 # asm 1: add  <rax=int64#7,<q31=int64#6
@@ -427,7 +427,7 @@ adc %rdx,%r10
 movq   48(%rsi),%rax
 
 # qhasm: (uint128) rdx rax = rax * *(uint64 *) &crypto_sign_ed25519_amd64_64_MU0
-mulq  crypto_sign_ed25519_amd64_64_MU0
+mulq  crypto_sign_ed25519_amd64_64_MU0(%rip)
 
 # qhasm: carry? q23 += rax
 # asm 1: add  <rax=int64#7,<q23=int64#10
@@ -450,7 +450,7 @@ adc %rdx,%r12
 movq   48(%rsi),%rax
 
 # qhasm: (uint128) rdx rax = rax * *(uint64 *) &crypto_sign_ed25519_amd64_64_MU1
-mulq  crypto_sign_ed25519_amd64_64_MU1
+mulq  crypto_sign_ed25519_amd64_64_MU1(%rip)
 
 # qhasm: carry? q24 += rax
 # asm 1: add  <rax=int64#7,<q24=int64#12
@@ -483,7 +483,7 @@ adc %rdx,%r12
 movq   48(%rsi),%rax
 
 # qhasm: (uint128) rdx rax = rax * *(uint64 *) &crypto_sign_ed25519_amd64_64_MU2
-mulq  crypto_sign_ed25519_amd64_64_MU2
+mulq  crypto_sign_ed25519_amd64_64_MU2(%rip)
 
 # qhasm: carry? q30 += rax
 # asm 1: add  <rax=int64#7,<q30=int64#5
@@ -516,7 +516,7 @@ adc %rdx,%r12
 movq   48(%rsi),%rax
 
 # qhasm: (uint128) rdx rax = rax * *(uint64 *) &crypto_sign_ed25519_amd64_64_MU3
-mulq  crypto_sign_ed25519_amd64_64_MU3
+mulq  crypto_sign_ed25519_amd64_64_MU3(%rip)
 
 # qhasm: carry? q31 += rax
 # asm 1: add  <rax=int64#7,<q31=int64#6
@@ -549,7 +549,7 @@ adc %rdx,%r12
 movq   48(%rsi),%rax
 
 # qhasm: (uint128) rdx rax = rax * *(uint64 *) &crypto_sign_ed25519_amd64_64_MU4
-mulq  crypto_sign_ed25519_amd64_64_MU4
+mulq  crypto_sign_ed25519_amd64_64_MU4(%rip)
 
 # qhasm: carry? q32 += rax 
 # asm 1: add  <rax=int64#7,<q32=int64#8
@@ -577,7 +577,7 @@ adc %rdx,%r11
 movq   56(%rsi),%rax
 
 # qhasm: (uint128) rdx rax = rax * *(uint64 *) &crypto_sign_ed25519_amd64_64_MU0
-mulq  crypto_sign_ed25519_amd64_64_MU0
+mulq  crypto_sign_ed25519_amd64_64_MU0(%rip)
 
 # qhasm: carry? q24 += rax
 # asm 1: add  <rax=int64#7,<q24=int64#12
@@ -602,7 +602,7 @@ adc %rdx,%r12
 movq   56(%rsi),%rax
 
 # qhasm: (uint128) rdx rax = rax * *(uint64 *) &crypto_sign_ed25519_amd64_64_MU1
-mulq  crypto_sign_ed25519_amd64_64_MU1
+mulq  crypto_sign_ed25519_amd64_64_MU1(%rip)
 
 # qhasm: carry? q30 += rax
 # asm 1: add  <rax=int64#7,<q30=int64#5
@@ -640,7 +640,7 @@ movq %r8,56(%rsp)
 movq   56(%rsi),%rax
 
 # qhasm: (uint128) rdx rax = rax * *(uint64 *) &crypto_sign_ed25519_amd64_64_MU2
-mulq  crypto_sign_ed25519_amd64_64_MU2
+mulq  crypto_sign_ed25519_amd64_64_MU2(%rip)
 
 # qhasm: carry? q31 += rax
 # asm 1: add  <rax=int64#7,<q31=int64#6
@@ -678,7 +678,7 @@ movq %r9,64(%rsp)
 movq   56(%rsi),%rax
 
 # qhasm: (uint128) rdx rax = rax * *(uint64 *) &crypto_sign_ed25519_amd64_64_MU3
-mulq  crypto_sign_ed25519_amd64_64_MU3
+mulq  crypto_sign_ed25519_amd64_64_MU3(%rip)
 
 # qhasm: carry? q32 += rax
 # asm 1: add  <rax=int64#7,<q32=int64#8
@@ -716,7 +716,7 @@ movq %r10,72(%rsp)
 movq   56(%rsi),%rax
 
 # qhasm: (uint128) rdx rax = rax * *(uint64 *) &crypto_sign_ed25519_amd64_64_MU4
-mulq  crypto_sign_ed25519_amd64_64_MU4
+mulq  crypto_sign_ed25519_amd64_64_MU4(%rip)
 
 # qhasm: carry? q33 += rax 
 # asm 1: add  <rax=int64#7,<q33=int64#9
@@ -744,7 +744,7 @@ movq %r11,80(%rsp)
 movq 56(%rsp),%rax
 
 # qhasm: (uint128) rdx rax = rax * *(uint64 *) &crypto_sign_ed25519_amd64_64_ORDER0
-mulq  crypto_sign_ed25519_amd64_64_ORDER0
+mulq  crypto_sign_ed25519_amd64_64_ORDER0(%rip)
 
 # qhasm: r20 = rax
 # asm 1: mov  <rax=int64#7,>r20=int64#5
@@ -762,7 +762,7 @@ mov  %rdx,%r9
 movq 56(%rsp),%rax
 
 # qhasm: (uint128) rdx rax = rax * *(uint64 *) &crypto_sign_ed25519_amd64_64_ORDER1
-mulq  crypto_sign_ed25519_amd64_64_ORDER1
+mulq  crypto_sign_ed25519_amd64_64_ORDER1(%rip)
 
 # qhasm: r21 = rax
 # asm 1: mov  <rax=int64#7,>r21=int64#8
@@ -790,7 +790,7 @@ adc %rdx,%r9
 movq 56(%rsp),%rax
 
 # qhasm: (uint128) rdx rax = rax * *(uint64 *) &crypto_sign_ed25519_amd64_64_ORDER2
-mulq  crypto_sign_ed25519_amd64_64_ORDER2
+mulq  crypto_sign_ed25519_amd64_64_ORDER2(%rip)
 
 # qhasm: r22 = rax
 # asm 1: mov  <rax=int64#7,>r22=int64#9
@@ -818,7 +818,7 @@ adc %rdx,%r9
 movq 56(%rsp),%rax
 
 # qhasm: (uint128) rdx rax = rax * *(uint64 *) &crypto_sign_ed25519_amd64_64_ORDER3
-mulq  crypto_sign_ed25519_amd64_64_ORDER3
+mulq  crypto_sign_ed25519_amd64_64_ORDER3(%rip)
 
 # qhasm: free rdx
 
@@ -838,7 +838,7 @@ add  %r9,%r12
 movq 64(%rsp),%rax
 
 # qhasm: (uint128) rdx rax = rax * *(uint64 *) &crypto_sign_ed25519_amd64_64_ORDER0
-mulq  crypto_sign_ed25519_amd64_64_ORDER0
+mulq  crypto_sign_ed25519_amd64_64_ORDER0(%rip)
 
 # qhasm: carry? r21 += rax
 # asm 1: add  <rax=int64#7,<r21=int64#8
@@ -861,7 +861,7 @@ adc %rdx,%r9
 movq 64(%rsp),%rax
 
 # qhasm: (uint128) rdx rax = rax * *(uint64 *) &crypto_sign_ed25519_amd64_64_ORDER1
-mulq  crypto_sign_ed25519_amd64_64_ORDER1
+mulq  crypto_sign_ed25519_amd64_64_ORDER1(%rip)
 
 # qhasm: carry? r22 += rax
 # asm 1: add  <rax=int64#7,<r22=int64#9
@@ -894,7 +894,7 @@ adc %rdx,%rcx
 movq 64(%rsp),%rax
 
 # qhasm: (uint128) rdx rax = rax * *(uint64 *) &crypto_sign_ed25519_amd64_64_ORDER2
-mulq  crypto_sign_ed25519_amd64_64_ORDER2
+mulq  crypto_sign_ed25519_amd64_64_ORDER2(%rip)
 
 # qhasm: free rdx
 
@@ -914,7 +914,7 @@ add  %rcx,%r12
 movq 72(%rsp),%rax
 
 # qhasm: (uint128) rdx rax = rax * *(uint64 *) &crypto_sign_ed25519_amd64_64_ORDER0
-mulq  crypto_sign_ed25519_amd64_64_ORDER0
+mulq  crypto_sign_ed25519_amd64_64_ORDER0(%rip)
 
 # qhasm: carry? r22 += rax
 # asm 1: add  <rax=int64#7,<r22=int64#9
@@ -937,7 +937,7 @@ adc %rdx,%rcx
 movq 72(%rsp),%rax
 
 # qhasm: (uint128) rdx rax = rax * *(uint64 *) &crypto_sign_ed25519_amd64_64_ORDER1
-mulq  crypto_sign_ed25519_amd64_64_ORDER1
+mulq  crypto_sign_ed25519_amd64_64_ORDER1(%rip)
 
 # qhasm: free rdx
 
@@ -957,7 +957,7 @@ add  %rcx,%r12
 movq 80(%rsp),%rax
 
 # qhasm: (uint128) rdx rax = rax * *(uint64 *) &crypto_sign_ed25519_amd64_64_ORDER0
-mulq  crypto_sign_ed25519_amd64_64_ORDER0
+mulq  crypto_sign_ed25519_amd64_64_ORDER0(%rip)
 
 # qhasm: free rdx
 
@@ -1029,22 +1029,22 @@ mov  %rsi,%r11
 # qhasm: carry? t0 -= *(uint64 *) &crypto_sign_ed25519_amd64_64_ORDER0
 # asm 1: sub  crypto_sign_ed25519_amd64_64_ORDER0,<t0=int64#4
 # asm 2: sub  crypto_sign_ed25519_amd64_64_ORDER0,<t0=%rcx
-sub  crypto_sign_ed25519_amd64_64_ORDER0,%rcx
+sub  crypto_sign_ed25519_amd64_64_ORDER0(%rip),%rcx
 
 # qhasm: carry? t1 -= *(uint64 *) &crypto_sign_ed25519_amd64_64_ORDER1 - carry
 # asm 1: sbb  crypto_sign_ed25519_amd64_64_ORDER1,<t1=int64#6
 # asm 2: sbb  crypto_sign_ed25519_amd64_64_ORDER1,<t1=%r9
-sbb  crypto_sign_ed25519_amd64_64_ORDER1,%r9
+sbb  crypto_sign_ed25519_amd64_64_ORDER1(%rip),%r9
 
 # qhasm: carry? t2 -= *(uint64 *) &crypto_sign_ed25519_amd64_64_ORDER2 - carry
 # asm 1: sbb  crypto_sign_ed25519_amd64_64_ORDER2,<t2=int64#8
 # asm 2: sbb  crypto_sign_ed25519_amd64_64_ORDER2,<t2=%r10
-sbb  crypto_sign_ed25519_amd64_64_ORDER2,%r10
+sbb  crypto_sign_ed25519_amd64_64_ORDER2(%rip),%r10
 
 # qhasm: unsigned<? t3 -= *(uint64 *) &crypto_sign_ed25519_amd64_64_ORDER3 - carry
 # asm 1: sbb  crypto_sign_ed25519_amd64_64_ORDER3,<t3=int64#9
 # asm 2: sbb  crypto_sign_ed25519_amd64_64_ORDER3,<t3=%r11
-sbb  crypto_sign_ed25519_amd64_64_ORDER3,%r11
+sbb  crypto_sign_ed25519_amd64_64_ORDER3(%rip),%r11
 
 # qhasm: r0 = t0 if !unsigned<
 # asm 1: cmovae <t0=int64#4,<r0=int64#3
@@ -1089,22 +1089,22 @@ mov  %rsi,%r11
 # qhasm: carry? t0 -= *(uint64 *) &crypto_sign_ed25519_amd64_64_ORDER0
 # asm 1: sub  crypto_sign_ed25519_amd64_64_ORDER0,<t0=int64#4
 # asm 2: sub  crypto_sign_ed25519_amd64_64_ORDER0,<t0=%rcx
-sub  crypto_sign_ed25519_amd64_64_ORDER0,%rcx
+sub  crypto_sign_ed25519_amd64_64_ORDER0(%rip),%rcx
 
 # qhasm: carry? t1 -= *(uint64 *) &crypto_sign_ed25519_amd64_64_ORDER1 - carry
 # asm 1: sbb  crypto_sign_ed25519_amd64_64_ORDER1,<t1=int64#6
 # asm 2: sbb  crypto_sign_ed25519_amd64_64_ORDER1,<t1=%r9
-sbb  crypto_sign_ed25519_amd64_64_ORDER1,%r9
+sbb  crypto_sign_ed25519_amd64_64_ORDER1(%rip),%r9
 
 # qhasm: carry? t2 -= *(uint64 *) &crypto_sign_ed25519_amd64_64_ORDER2 - carry
 # asm 1: sbb  crypto_sign_ed25519_amd64_64_ORDER2,<t2=int64#8
 # asm 2: sbb  crypto_sign_ed25519_amd64_64_ORDER2,<t2=%r10
-sbb  crypto_sign_ed25519_amd64_64_ORDER2,%r10
+sbb  crypto_sign_ed25519_amd64_64_ORDER2(%rip),%r10
 
 # qhasm: unsigned<? t3 -= *(uint64 *) &crypto_sign_ed25519_amd64_64_ORDER3 - carry
 # asm 1: sbb  crypto_sign_ed25519_amd64_64_ORDER3,<t3=int64#9
 # asm 2: sbb  crypto_sign_ed25519_amd64_64_ORDER3,<t3=%r11
-sbb  crypto_sign_ed25519_amd64_64_ORDER3,%r11
+sbb  crypto_sign_ed25519_amd64_64_ORDER3(%rip),%r11
 
 # qhasm: r0 = t0 if !unsigned<
 # asm 1: cmovae <t0=int64#4,<r0=int64#3


### PR DESCRIPTION
The Hyperledger implementation (https://github.com/hyperledger/iroha-ed25519) contains [changes to the assembly code](https://github.com/hyperledger/iroha-ed25519/tree/master/lib/ed25519/amd64-64-24k-pic) to allow PIC. This in turn fixes compilation/linking of ZeroTier One when "full hardening" flags are used.

This is a full fix for #717.