### PR TITLE
Fix invalid JSON in network member list

### DIFF
--- a/controller/EmbeddedNetworkController.cpp
+++ b/controller/EmbeddedNetworkController.cpp
@@ -551,7 +551,7 @@ unsigned int EmbeddedNetworkController::handleControlPlaneHttpGET(
 							for(auto member=members.begin();member!=members.end();++member) {
 								mid = (*member)["id"];
 								char tmp[128];
-								OSUtils::ztsnprintf(tmp,sizeof(tmp),"%s\"%s\":%llu",(responseBody.length() > 1) ? ",\"" : "\"",mid.c_str(),(unsigned long long)OSUtils::jsonInt((*member)["revision"],0));
+								OSUtils::ztsnprintf(tmp,sizeof(tmp),"%s\"%s\":%llu",(responseBody.length() > 1) ? "," : "",mid.c_str(),(unsigned long long)OSUtils::jsonInt((*member)["revision"],0));
 								responseBody.append(tmp);
 							}
 						}


### PR DESCRIPTION
`/controller/network/NWID/member` is returning an invalid JSON response. This appears to have just been a minor oversight when introducing the RethinkDB integration (https://github.com/zerotier/ZeroTierOne/commit/f5014d7d7179a77311f58f8bd0dced0ea83f2885#diff-7433eba40b07c5fb84c2b5f295789d80R544)

Actual behavior:
```
curl -s -X GET --header "X-ZT1-Auth: $authtoken" http://localhost:9993/controller/network/$nwid/member
{""member1":1,""member2":1}
```

Expected behavior:
```
curl -s -X GET --header "X-ZT1-Auth: $authtoken" http://localhost:9993/controller/network/$nwid/member
{"member1":1,"member2":1}
```

I don't have a development environment set up to test this, but it _seems_ pretty straight forward (famous last words).