### PR TITLE
fix clang C++17 deprecation when building with ZT_DEBUG=1

### DIFF
--- a/node/Packet.cpp
+++ b/node/Packet.cpp
@@ -332,7 +332,7 @@ static const int LZ4_minLength = (MFLIMIT+1);
 
 #define LZ4_STATIC_ASSERT(c)    { enum { LZ4_static_assert = 1/(int)(!!(c)) }; }   /* use only *after* variable declarations */
 
-static inline unsigned LZ4_NbCommonBytes (register reg_t val)
+static inline unsigned LZ4_NbCommonBytes (reg_t val)
 {
 	if (LZ4_isLittleEndian()) {
 	    if (sizeof(val)==8) {


### PR DESCRIPTION
I'd really like to get debug info out to our users via FreeBSD ports; however I get a failure when building with ZT_DEBUG=1

> node/Packet.cpp:335:43: error: 'register' storage class specifier is deprecated and incompatible with C++17 [-Werror,-Wdeprecated-register]

This has been deprecated, and as far as I can see it's simply a compiler hint so we can simply remove it -- see http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4340

> OS: FreeBSD 12.0-CURRENT amd64
> CC: clang++ 6.0.0
> MAKE: GNU Make 4.2.1

```
dch@wintermute /u/p/n/zerotier> gmake --version
GNU Make 4.2.1
Built for amd64-portbld-freebsd12.0
Copyright (C) 1988-2016 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
dch@wintermute /u/p/n/zerotier> uname -a
FreeBSD wintermute.skunkwerks.at 12.0-CURRENT FreeBSD 12.0-CURRENT  r333761+cdcdb3cf1f15(master)  amd64
dch@wintermute /u/p/n/zerotier> clang++ --version
FreeBSD clang version 6.0.0 (tags/RELEASE_600/final 326565) (based on LLVM 6.0.0)
Target: x86_64-unknown-freebsd12.0
Thread model: posix
InstalledDir: /usr/bin
dch@wintermute /u/p/n/zerotier> 
```
```
===>  License GPLv3 accepted by the user
===>   zerotier-1.2.8 depends on file: /usr/local/sbin/pkg - found
===> Fetching all distfiles required by zerotier-1.2.8 for building
=> SHA256 Checksum OK for zerotier-ZeroTierOne-1.2.8_GH0.tar.gz.
===>  Extracting for zerotier-1.2.8
===>  Patching for zerotier-1.2.8
===>  Applying FreeBSD patches for zerotier-1.2.8
===>   zerotier-1.2.8 depends on executable: gmake - found
===>  Configuring for zerotier-1.2.8
===>  Building for zerotier-1.2.8
gmake[1]: Entering directory '/tmp/projects/freebsd/wip/zerotier/work/ZeroTierOne-1.2.8'
gmake -j 4 ZT_DEBUG=1
gmake[2]: Entering directory '/tmp/projects/freebsd/wip/zerotier/work/ZeroTierOne-1.2.8'
gmake[2]: warning: -jN forced in submake: disabling jobserver mode.
clang++ -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11  -Wall -O2 -g -pthread   -DZT_TRACE -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11    -c -o node/C25519.o node/C25519.cpp
clang++ -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11  -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -Wall -Werror -g -pthread   -DZT_TRACE -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11    -c -o node/Capability.o node/Capability.cpp
clang++ -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11  -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -Wall -Werror -g -pthread   -DZT_TRACE -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11    -c -o node/CertificateOfMembership.o node/CertificateOfMembership.cpp
clang++ -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11  -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -Wall -Werror -g -pthread   -DZT_TRACE -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11    -c -o node/CertificateOfOwnership.o node/CertificateOfOwnership.cpp
clang++ -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11  -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -Wall -Werror -g -pthread   -DZT_TRACE -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11    -c -o node/Identity.o node/Identity.cpp
clang++ -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11  -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -Wall -Werror -g -pthread   -DZT_TRACE -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11    -c -o node/IncomingPacket.o node/IncomingPacket.cpp
clang++ -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11  -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -Wall -Werror -g -pthread   -DZT_TRACE -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11    -c -o node/InetAddress.o node/InetAddress.cpp
clang++ -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11  -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -Wall -Werror -g -pthread   -DZT_TRACE -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11    -c -o node/Membership.o node/Membership.cpp
clang++ -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11  -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -Wall -Werror -g -pthread   -DZT_TRACE -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11    -c -o node/Multicaster.o node/Multicaster.cpp
clang++ -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11  -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -Wall -Werror -g -pthread   -DZT_TRACE -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11    -c -o node/Network.o node/Network.cpp
clang++ -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11  -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -Wall -Werror -g -pthread   -DZT_TRACE -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11    -c -o node/NetworkConfig.o node/NetworkConfig.cpp
clang++ -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11  -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -Wall -Werror -g -pthread   -DZT_TRACE -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11    -c -o node/Node.o node/Node.cpp
clang++ -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11  -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -Wall -Werror -g -pthread   -DZT_TRACE -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11    -c -o node/OutboundMulticast.o node/OutboundMulticast.cpp
clang++ -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11  -pipe -fno-omit-frame-pointer -flax-vector-conversions -g -fstack-protector -fno-strict-aliasing -Wall -fPIE -fvisibility=hidden -fstack-protector -pthread  -DNDEBUG  -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -Wall -Werror -g -pthread   -DZT_TRACE -DZT_USE_X64_ASM_SALSA2012 -DZT_BUILD_PLATFORM=7 -DZT_BUILD_ARCHITECTURE=2 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -fno-rtti -std=c++11    -c -o node/Packet.o node/Packet.cpp
node/Packet.cpp:335:43: error: 'register' storage class specifier is deprecated and incompatible with C++17 [-Werror,-Wdeprecated-register]
static inline unsigned LZ4_NbCommonBytes (register reg_t val)
                                          ^~~~~~~~~
1 error generated.
gmake[2]: *** [<builtin>: node/Packet.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
gmake[2]: Leaving directory '/tmp/projects/freebsd/wip/zerotier/work/ZeroTierOne-1.2.8'
gmake[1]: *** [make-bsd.mk:162: debug] Error 2
gmake[1]: Leaving directory '/tmp/projects/freebsd/wip/zerotier/work/ZeroTierOne-1.2.8'
===> Compilation failed unexpectedly.
Try to set MAKE_JOBS_UNSAFE=yes and rebuild before reporting the failure to
the maintainer.
*** Error code 1

Stop.
make: stopped in /projects/freebsd/wip/zerotier
```