### PR TITLE
fix MAC address rule parsing as even/uneven switches at every colon

### DIFF
--- a/rule-compiler/rule-compiler.js
+++ b/rule-compiler/rule-compiler.js
@@ -226,12 +226,16 @@ function _cleanMac(m)
 {
 	m = m.toLowerCase();
 	var m2 = '';
+	let charcount = 0;
 	for(let i=0;((i<m.length)&&(m2.length<17));++i) {
 		let c = m.charAt(i);
 		if ("0123456789abcdef".indexOf(c) >= 0) {
 			m2 += c;
-			if ((m2.length > 0)&&(m2.length !== 17)&&((m2.length & 1) === 0))
+			charcount++;
+			if ((m2.length > 0)&&(m2.length !== 17)&&(charcount >= 2) ) {
 				m2 += ':';
+				charcount=0;
+			}
 		}
 	}
 	return m2;


### PR DESCRIPTION
currently mac address rules do not parse correctly

drop macsrc aabbccddeeff;
drop macsrc 11:22:33:44:55:66;

both produce json with broken MACs, this patch should fix this issue