### PR TITLE
Add Linux route metrics

### DIFF
--- a/node/Constants.hpp
+++ b/node/Constants.hpp
@@ -460,4 +460,10 @@
 #define ZT_EXCEPTION_INVALID_SERIALIZED_DATA_INVALID_CRYPTOGRAPHIC_TOKEN 202
 #define ZT_EXCEPTION_INVALID_SERIALIZED_DATA_BAD_ENCODING 203
 
+// Interface and route metric for ZeroTier taps -- this ensures that
+// if we are on WiFi and also bridged via ZeroTier to the same LAN
+// traffic will (if the OS is sane) prefer WiFi.
+#define ZT_IF_METRIC 5000
+#define ZT_IF_METRIC_STRING "5000"
+
 #endif

--- a/osdep/ManagedRoute.cpp
+++ b/osdep/ManagedRoute.cpp
@@ -288,11 +288,11 @@ static void _routeCmd(const char *op,const InetAddress &target,const InetAddress
 		::close(STDERR_FILENO);
 		char ipbuf[64],ipbuf2[64];
 		if (via) {
-			::execl(ZT_LINUX_IP_COMMAND,ZT_LINUX_IP_COMMAND,(target.ss_family == AF_INET6) ? "-6" : "-4","route",op,target.toString(ipbuf),"via",via.toIpString(ipbuf2),(const char *)0);
-			::execl(ZT_LINUX_IP_COMMAND_2,ZT_LINUX_IP_COMMAND_2,(target.ss_family == AF_INET6) ? "-6" : "-4","route",op,target.toString(ipbuf),"via",via.toIpString(ipbuf2),(const char *)0);
+			::execl(ZT_LINUX_IP_COMMAND,ZT_LINUX_IP_COMMAND,(target.ss_family == AF_INET6) ? "-6" : "-4","route",op,target.toString(ipbuf),"via",via.toIpString(ipbuf2),"metric",ZT_IF_METRIC_STRING,(const char *)0);
+			::execl(ZT_LINUX_IP_COMMAND_2,ZT_LINUX_IP_COMMAND_2,(target.ss_family == AF_INET6) ? "-6" : "-4","route",op,target.toString(ipbuf),"via",via.toIpString(ipbuf2),"metric",ZT_IF_METRIC_STRING,(const char *)0);
 		} else if ((localInterface)&&(localInterface[0])) {
-			::execl(ZT_LINUX_IP_COMMAND,ZT_LINUX_IP_COMMAND,(target.ss_family == AF_INET6) ? "-6" : "-4","route",op,target.toString(ipbuf),"dev",localInterface,(const char *)0);
-			::execl(ZT_LINUX_IP_COMMAND_2,ZT_LINUX_IP_COMMAND_2,(target.ss_family == AF_INET6) ? "-6" : "-4","route",op,target.toString(ipbuf),"dev",localInterface,(const char *)0);
+			::execl(ZT_LINUX_IP_COMMAND,ZT_LINUX_IP_COMMAND,(target.ss_family == AF_INET6) ? "-6" : "-4","route",op,target.toString(ipbuf),"dev",localInterface,"metric",ZT_IF_METRIC_STRING,(const char *)0);
+			::execl(ZT_LINUX_IP_COMMAND_2,ZT_LINUX_IP_COMMAND_2,(target.ss_family == AF_INET6) ? "-6" : "-4","route",op,target.toString(ipbuf),"dev",localInterface,"metric",ZT_IF_METRIC_STRING,(const char *)0);
 		}
 		::_exit(-1);
 	}

--- a/service/OneService.cpp
+++ b/service/OneService.cpp
@@ -137,10 +137,6 @@ namespace ZeroTier { typedef BSDEthernetTap EthernetTap; }
 #define ZT_MAX_HTTP_MESSAGE_SIZE (1024 * 1024 * 64)
 #define ZT_MAX_HTTP_CONNECTIONS 65536
 
-// Interface metric for ZeroTier taps -- this ensures that if we are on WiFi and also
-// bridged via ZeroTier to the same LAN traffic will (if the OS is sane) prefer WiFi.
-#define ZT_IF_METRIC 5000
-
 // How often to check for new multicast subscriptions on a tap device
 #define ZT_TAP_CHECK_MULTICAST_INTERVAL 5000
 


### PR DESCRIPTION
Add metrics based on ZT_IF_METRIC.
There are negative implications of this - when somebody connected over zerotiers enters network that is same as one routed through managed routes, it might result in data leak as data are send to nodes in different network directly (not over zt). However, this is what allegedly happens on other platforms due to high interface metric, so this makes this Linux consistent with other platforms (who are in majority and this is what most people want anyway).
It is not marvel of great engineering, but propagating something hrough zt code is not exactly easy.
Tested on Arch and Fedora.