### PR TITLE
Update ZeroTier version on Docker

### DIFF
--- a/ext/installfiles/linux/zerotier-containerized/Dockerfile
+++ b/ext/installfiles/linux/zerotier-containerized/Dockerfile
@@ -1,7 +1,16 @@
+FROM debian:stretch as builder
+
+## Supports x86_64, x86, arm, and arm64
+
+RUN apt-get update && apt-get install -y curl gnupg
+RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 0x1657198823e52a61  && \
+    echo "deb http://download.zerotier.com/debian/stretch stretch main" > /etc/apt/sources.list.d/zerotier.list
+RUN apt-get update && apt-get install -y zerotier-one=1.2.12
+
 FROM alpine:latest
 MAINTAINER Adam Ierymenko <adam.ierymenko@zerotier.com>
 
-LABEL version="1.2.4"
+LABEL version="1.2.12"
 LABEL description="Containerized ZeroTier One for use on CoreOS or other Docker-only Linux hosts."
 
 # Uncomment to build in container
@@ -9,12 +18,13 @@ LABEL description="Containerized ZeroTier One for use on CoreOS or other Docker-
 
 RUN apk add --update libgcc libstdc++
 
-ADD zerotier-one /
-RUN chmod 0755 /zerotier-one
-RUN ln -sf /zerotier-one /zerotier-cli
 RUN mkdir -p /var/lib/zerotier-one
+
+COPY --from=builder /var/lib/zerotier-one/zerotier-cli /usr/sbin/zerotier-cli
+COPY --from=builder /var/lib/zerotier-one/zerotier-idtool /usr/sbin/zerotier-idtool
+COPY --from=builder /usr/sbin/zerotier-one /usr/sbin/zerotier-one
 
 ADD main.sh /
 RUN chmod 0755 /main.sh
-
-ENTRYPOINT /main.sh
+ENTRYPOINT ["/main.sh"]
+CMD ["zerotier-one"]

--- a/ext/installfiles/linux/zerotier-containerized/main.sh
+++ b/ext/installfiles/linux/zerotier-containerized/main.sh
@@ -7,4 +7,4 @@ if [ ! -e /dev/net/tun ]; then
 	exit 1
 fi
 
-exec /zerotier-one
+exec "$@"


### PR DESCRIPTION
This commit changes the Dockerfile ot use the multi-stage build and help
to get an automated build on Docker.

The idea of the multi-stage build is to use the already stable Debian
distribution channel to provide up-to-date versions of ZeroTier.

The benefit is that it would be possible to automate the image build,
either on Docker Hub, Travis or taking advantage of the [docker-library/official-images] infrastructure.

This changes follows the best-practices suggested by
[docker-library/official-images], such as using a High Availability GPG
keyserver, providing a default CMD, allowing "bash" on `docker run` and
others.

Given that both the builder `debian:stretch` and `alpine:latest` are
official messages and have [manifests], this means that this Dockerfile
is also multi-platform. This means that this same Dockerfile will
pick-up the correct Debian package according to the architecture of the
running system during build.

With this changes we could try to promote the image to be parte of
[docker-library/official-images], and take advantage of automated
publishing of multi-architecture images. Others would be able to use
`docker run zerotier` and download the latest version appropriate to
their system.

Related to #682

[docker-library/official-images]: https://github.com/docker-library/official-images
[manifests]: https://blog.docker.com/2017/09/docker-official-images-now-multi-platform/