### PR TITLE
Don't relink zerotier-one every time.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,7 @@ about: Create a report to help us improve
 **Alternative, faster ways to get help**
 If you have just started using ZeroTier, here are some places to get help:
 - my.zerotier.com has a _Community_ tab. It's a live chat with other users and the developers. 
-- [ZeroTier Knowledge Base](https://support.zerotier.com/knowledgebase.php?s=MQ__)
+- [ZeroTier Knowledge Base](https://zerotier.atlassian.net/wiki/spaces/SD/overview)
 - www.zerotier.com has a Contact Us button
 - email contact@zerotier.com
 

--- a/controller/README.md
+++ b/controller/README.md
@@ -208,14 +208,6 @@ Important notes about rules engine behavior:
 
 This returns a JSON object containing all member IDs as keys and their `memberRevisionCounter` values as values.
 
-#### `/controller/network/<network ID>/active`
-
- * Purpose: Get a set of all active members on this network
- * Methods: GET
- * Returns: { object }
-
-This returns an object containing all currently online members and the most recent `recentLog` entries for their last request.
-
 #### `/controller/network/<network ID>/member/<address>`
 
  * Purpose: Create, authorize, or remove a network member

--- a/make-linux.mk
+++ b/make-linux.mk
@@ -257,19 +257,21 @@ ifeq ($(ZT_USE_ARM32_NEON_ASM_CRYPTO),1)
 	override CORE_OBJS+=ext/arm32-neon-salsa2012-asm/salsa2012.o
 endif
 
+.PHONY: all
 all:	one
 
-one:	$(CORE_OBJS) $(ONE_OBJS) one.o
+.PHONY: one
+one: zerotier-one zerotier-idtool zerotier-cli
+
+zerotier-one:	$(CORE_OBJS) $(ONE_OBJS) one.o
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o zerotier-one $(CORE_OBJS) $(ONE_OBJS) one.o $(LDLIBS)
 	$(STRIP) zerotier-one
+
+zerotier-idtool: zerotier-one
 	ln -sf zerotier-one zerotier-idtool
+
+zerotier-cli: zerotier-one
 	ln -sf zerotier-one zerotier-cli
-
-zerotier-one: one
-
-zerotier-idtool: one
-
-zerotier-cli: one
 
 libzerotiercore.a:	FORCE
 	make CFLAGS="-O3 -fstack-protector -fPIC" CXXFLAGS="-O3 -std=c++11 -fstack-protector -fPIC" $(CORE_OBJS)

--- a/service/README.md
+++ b/service/README.md
@@ -5,7 +5,7 @@ This is the actual implementation of ZeroTier One, a service providing connectiv
 
 ### Local Configuration File
 
-A file called `local.conf` in the ZeroTier home folder contains configuration options that apply to the local node. It can be used to set up trusted paths, blacklist physical paths, set up physical path hints for certain nodes, and define trusted upstream devices (federated roots). In a large deployment it can be deployed using a tool like Puppet, Chef, SaltStack, etc. to set a uniform configuration across systems. It's a JSON format file that can also be edited and rewritten by ZeroTier One itself, so ensure that proper JSON formatting is used.
+A file called `local.conf` in the ZeroTier home folder contains configuration options that apply to the local node. (It does not exist unless you create it). It can be used to set up trusted paths, blacklist physical paths, set up physical path hints for certain nodes, and define trusted upstream devices (federated roots). In a large deployment it can be deployed using a tool like Puppet, Chef, SaltStack, etc. to set a uniform configuration across systems. It's a JSON format file that can also be edited and rewritten by ZeroTier One itself, so ensure that proper JSON formatting is used. 
 
 Settings available in `local.conf` (this is not valid JSON, and JSON does not allow comments):
 


### PR DESCRIPTION
Because zerotier-one depends on "one", which is a phony target,
making it relinks zerotier-one every time, which is probably
not the desired behavior.

In any case, zerotier-one, zerotier-cli, and zerotier-idtool are
real target, so they should have real dependencies and actions.
The "one" target now depends on these three files.

Behavior is mostly unchanged otherwise.