### PR TITLE
Fix ubuntu service to ensure Zerotier stops nicely.

### DIFF
--- a/debian/zerotier-one.service
+++ b/debian/zerotier-one.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=ZeroTier One
-After=network-online.target
+After=network.target
 Wants=network-online.target
 
 [Service]


### PR DESCRIPTION
As explained in #738, the Ubuntu service is not stopping properly. It was initially due to the missing `
Wants=network-online.target` but is now caused by the wrong `After` argument.

Changing the service argument from `After=network-online.target` to `After=network.target` will ensure the service to stop nicely and avoid the 90 seconds delay before Ubuntu kills Zerotier.

It was only tested on `Ubuntu 18.04`.