### PR TITLE
Fix missing return value compile warning

### DIFF
--- a/node/Utils.hpp
+++ b/node/Utils.hpp
@@ -375,7 +375,9 @@ public:
 #if defined(__GNUC__)
 #if defined(__FreeBSD__)
 		return bswap64(n);
-#elif (!defined(__OpenBSD__))
+#elif defined(__OpenBSD__)
+		return swap64(n);
+#else
 		return __builtin_bswap64(n);
 #endif
 #else
@@ -408,7 +410,9 @@ public:
 #if defined(__GNUC__)
 #if defined(__FreeBSD__)
 		return bswap64(n);
-#elif (!defined(__OpenBSD__))
+#elif defined(__OpenBSD__)
+		return swap64(n);
+#else
 		return __builtin_bswap64(n);
 #endif
 #else


### PR DESCRIPTION
This fixes #987, tested on OpenBSD 6.4 amd64, OpenBSD 6.4 i386, OpenBSD 6.5 i386