### PR TITLE
Support DragonFly BSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ ifeq ($(OSTYPE),FreeBSD)
 	ZT_BUILD_PLATFORM=7
 	include make-bsd.mk
 endif
+ifeq ($(OSTYPE),DragonFly)
+	ZT_BUILD_PLATFORM=8
+	include make-bsd.mk
+endif
 ifeq ($(OSTYPE),OpenBSD)
 	CC=egcc
 	CXX=eg++

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The base path contains the ZeroTier One service main entry point (`one.cpp`), se
 
 ### Build and Platform Notes
 
-To build on Mac and Linux just type `make`. On FreeBSD and OpenBSD `gmake` (GNU make) is required and can be installed from packages or ports. For Windows there is a Visual Studio solution in `windows/'.
+To build on Mac and Linux just type `make`. On FreeBSD, DragonFly BSD, and OpenBSD `gmake` (GNU make) is required and can be installed from packages or ports. For Windows there is a Visual Studio solution in `windows/'.
 
  - **Mac**
    - Xcode command line tools for OSX 10.8 or newer are required.
@@ -55,6 +55,8 @@ To build on Mac and Linux just type `make`. On FreeBSD and OpenBSD `gmake` (GNU 
    - Windows 7 or newer is supported. This *may* work on Vista but isn't officially supported there. It will not work on Windows XP.
    - We build with Visual Studio 2017. Older versions may not work. Clang or MinGW will also probably work but may require some makefile hacking.
  - **FreeBSD**
+   - GNU make is required. Type `gmake` to build.
+ - **DragonFly BSD**
    - GNU make is required. Type `gmake` to build.
  - **OpenBSD**
    - There is a limit of four network memberships on OpenBSD as there are only four tap devices (`/dev/tap0` through `/dev/tap3`).
@@ -77,7 +79,7 @@ The service is controlled via the JSON API, which by default is available at 127
 Here's where home folders live (by default) on each OS:
 
  * **Linux**: `/var/lib/zerotier-one`
- * **FreeBSD** / **OpenBSD**: `/var/db/zerotier-one`
+ * **FreeBSD** / **DragonFly BSD** / **OpenBSD**: `/var/db/zerotier-one`
  * **Mac**: `/Library/Application Support/ZeroTier/One`
  * **Windows**: `\ProgramData\ZeroTier\One` (That's for Windows 7. The base 'shared app data' folder might be different on different Windows versions.)
 

--- a/include/ZeroTierDebug.h
+++ b/include/ZeroTierDebug.h
@@ -66,6 +66,9 @@
 #ifdef __FreeBSD__
   #define ZT_THREAD_ID (long)0 // (long)gettid()
 #endif
+#ifdef __DragonFly__
+  #define ZT_THREAD_ID (long)0 // (long)gettid()
+#endif
 #ifdef _WIN32
   #define ZT_THREAD_ID (long)0 //
 #endif
@@ -86,7 +89,7 @@
 			#define DEBUG_INFO(fmt, ...) fprintf(stderr, ZT_GRN "INFO [%ld]: %17s:%5d:%25s: " fmt "\n" \
 					ZT_RESET, ZT_THREAD_ID, ZT_FILENAME, __LINE__, __FUNCTION__, __VA_ARGS__)
 		#endif
-		#if defined(__linux__) or defined(__APPLE__) or defined(__FreeBSD__)
+		#if defined(__linux__) or defined(__APPLE__) or defined(__FreeBSD__) or defined(__DragonFly__)
 			#define DEBUG_INFO(fmt, args ...) fprintf(stderr, ZT_GRN "INFO [%ld]: %17s:%5d:%25s: " fmt "\n" \
 					ZT_RESET, ZT_THREAD_ID, ZT_FILENAME, __LINE__, __FUNCTION__, ##args)
 		#endif

--- a/make-bsd.mk
+++ b/make-bsd.mk
@@ -11,6 +11,9 @@ ONE_OBJS+=osdep/BSDEthernetTap.o ext/http-parser/http_parser.o
 ifeq ($(ZT_SANITIZE),1)
 	SANFLAGS+=-fsanitize=address -DASAN_OPTIONS=symbolize=1
 endif
+ifeq ($(ZT_DEBUG_TRACE),1)
+	DEFS+=-DZT_DEBUG_TRACE
+endif
 # "make debug" is a shortcut for this
 ifeq ($(ZT_DEBUG),1)
 	CFLAGS+=-Wall -Werror -g -pthread $(INCLUDES) $(DEFS)
@@ -160,7 +163,7 @@ clean:
 	rm -rf *.a *.o node/*.o controller/*.o osdep/*.o service/*.o ext/http-parser/*.o build-* zerotier-one zerotier-idtool zerotier-selftest zerotier-cli $(ONE_OBJS) $(CORE_OBJS)
 
 debug:	FORCE
-	$(MAKE) -j ZT_DEBUG=1
+	$(MAKE) -j ZT_DEBUG=1 ZT_DEBUG_TRACE=1
 
 install:	one
 	rm -f /usr/local/sbin/zerotier-one

--- a/node/Constants.hpp
+++ b/node/Constants.hpp
@@ -59,7 +59,7 @@
 #include <machine/endian.h>
 #endif
 
-#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#if defined(__FreeBSD__) || defined(__DragonFly__) || defined(__OpenBSD__) || defined(__NetBSD__)
 #ifndef __UNIX_LIKE__
 #define __UNIX_LIKE__
 #endif

--- a/node/Utils.hpp
+++ b/node/Utils.hpp
@@ -25,7 +25,7 @@
 #include <vector>
 #include <map>
 
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__DragonFly__)
 #include <sys/endian.h>
 #endif
 
@@ -373,7 +373,7 @@ public:
 	{
 #if __BYTE_ORDER == __LITTLE_ENDIAN
 #if defined(__GNUC__)
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__DragonFly__)
 		return bswap64(n);
 #elif (!defined(__OpenBSD__))
 		return __builtin_bswap64(n);
@@ -406,7 +406,7 @@ public:
 	{
 #if __BYTE_ORDER == __LITTLE_ENDIAN
 #if defined(__GNUC__)
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__DragonFly__)
 		return bswap64(n);
 #elif (!defined(__OpenBSD__))
 		return __builtin_bswap64(n);

--- a/osdep/BSDEthernetTap.cpp
+++ b/osdep/BSDEthernetTap.cpp
@@ -52,6 +52,10 @@
 #include "OSUtils.hpp"
 #include "BSDEthernetTap.hpp"
 
+#ifdef __DragonFly__
+#include "freebsd_getifmaddrs.h"
+#endif // __DragonFly__
+
 #define ZT_BASE32_CHARS "0123456789abcdefghijklmnopqrstuv"
 
 // ff:ff:ff:ff:ff:ff with no ADI
@@ -81,7 +85,7 @@ BSDEthernetTap::BSDEthernetTap(
 
 	Mutex::Lock _gl(globalTapCreateLock);
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__DragonFly__)
 	/* FreeBSD allows long interface names and interface renaming */
 
 	_dev = "zt";
@@ -163,7 +167,10 @@ BSDEthernetTap::BSDEthernetTap(
 	OSUtils::ztsnprintf(metstr,sizeof(metstr),"%u",_metric);
 	long cpid = (long)vfork();
 	if (cpid == 0) {
-		::execl("/sbin/ifconfig","/sbin/ifconfig",_dev.c_str(),"lladdr",ethaddr,"mtu",mtustr,"metric",metstr,"up",(const char *)0);
+		::execl("/sbin/ifconfig","/sbin/ifconfig",_dev.c_str(),"lladdr",ethaddr,"metric",metstr,"up",(const char *)0);
+#ifndef __DragonFly__
+		::execl("/sbin/ifconfig","/sbin/ifconfig",_dev.c_str(),"mtu",mtustr,(const char *)0);
+#endif // __DragonFly__
 		::_exit(-1);
 	} else if (cpid > 0) {
 		int exitcode = -1;

--- a/osdep/EthernetTap.cpp
+++ b/osdep/EthernetTap.cpp
@@ -43,6 +43,10 @@
 #include "BSDEthernetTap.hpp"
 #endif // __FreeBSD__
 
+#ifdef __DragonFly__
+#include "BSDEthernetTap.hpp"
+#endif // __DragonFly__
+
 #ifdef __NetBSD__
 #include "NetBSDEthernetTap.hpp"
 #endif // __NetBSD__
@@ -102,6 +106,10 @@ std::shared_ptr<EthernetTap> EthernetTap::newInstance(
 #ifdef __FreeBSD__
 	return std::shared_ptr<EthernetTap>(new BSDEthernetTap(homePath,mac,mtu,metric,nwid,friendlyName,handler,arg));
 #endif // __FreeBSD__
+
+#ifdef __DragonFly__
+	return std::shared_ptr<EthernetTap>(new BSDEthernetTap(homePath,mac,mtu,metric,nwid,friendlyName,handler,arg));
+#endif // __DragonFly__
 
 #ifdef __NetBSD__
 	return std::shared_ptr<EthernetTap>(new NetBSDEthernetTap(homePath,mac,mtu,metric,nwid,friendlyName,handler,arg));

--- a/osdep/freebsd_getifmaddrs.c
+++ b/osdep/freebsd_getifmaddrs.c
@@ -86,7 +86,7 @@ getifmaddrs(struct ifmaddrs **pif)
 	do {
 		if (sysctl(mib, 6, NULL, &needed, NULL, 0) < 0)
 			return (-1);
-		if ((buf = malloc(needed)) == NULL)
+		if ((buf = (char *)malloc(needed)) == NULL)
 			return (-1);
 		if (sysctl(mib, 6, buf, &needed, NULL, 0) < 0) {
 			if (errno != ENOMEM || ++ntry >= MAX_SYSCTL_TRY) {
@@ -122,7 +122,7 @@ getifmaddrs(struct ifmaddrs **pif)
 		}
 	}
 
-	data = malloc(sizeof(struct ifmaddrs) * icnt + dcnt);
+	data = (char *)malloc(sizeof(struct ifmaddrs) * icnt + dcnt);
 	if (data == NULL) {
 		free(buf);
 		return (-1);

--- a/osdep/freebsd_getifmaddrs.h
+++ b/osdep/freebsd_getifmaddrs.h
@@ -30,8 +30,8 @@
  *	BSDI ifaddrs.h,v 2.5 2000/02/23 14:51:59 dab Exp
  */
 
-#ifndef	_freebsd_getifmaddrs.h_
-#define	_freebsd_getifmaddrs.h_
+#ifndef	_freebsd_getifmaddrs_h_
+#define	_freebsd_getifmaddrs_h_
 
 /*
  * This may have been defined in <net/if.h>.  Note that if <net/if.h> is
@@ -51,6 +51,7 @@ struct ifmaddrs {
 #include <sys/cdefs.h>
 
 
+#if defined(__NetBSD__) || defined(__OpenBSD__)
 /*
  * Message format for use in obtaining information about multicast addresses
  * from the routing socket.
@@ -63,6 +64,7 @@ struct ifma_msghdr {
 	int	ifmam_flags;	/* value of ifa_flags */
 	int	ifmam_index;	/* index for associated ifp */
 };
+#endif // __NetBSD__ || __OpenBSD__
 
 
 extern int getifaddrs(struct ifaddrs **);


### PR DESCRIPTION
DragonFly BSD is a fork of FreeBSD 4.8 in 2003. They share many similarities, so this patch makes ZeroTierOne build and work in the similar way as on FreeBSD, except for the following two differences:

* DragonFly BSD doesn't have getifmaddrs(3).
* DragonFly BSD's tap(4) interface doesn't support to set MTU (well, until revision 500708).

I have tested that ZeroTierOne builds and works fine on the latest DragonFly BSD (master version as of 2019-09-17):

DragonFly v5.7.0.531.gb7d3e1-DEVELOPMENT #0: Tue Sep 17 16:13:34 UTC 2019

Meanwhile, define ZT_DEBUG_TRACE in `make-bsd.mk` when build the debug version.

In addition, I use the spare number `8` for `ZT_BUILD_PLATFORM` on DragonFly BSD.  If it's not OK, we can just change this.

Thank you for reviewing this patch.

Cheers,
Aaron