### PR TITLE
systemd: fix zerotier hanging on shutdown

### DIFF
--- a/debian/zerotier-one.service
+++ b/debian/zerotier-one.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=ZeroTier One
-After=network-online.target
+After=network-online.target network.target
 Wants=network-online.target
 
 [Service]


### PR DESCRIPTION
On system shutdown, zerotier is stopped after the network and gets
itself into a connection timeout loop. It hits the TimeoutStopUSec= and
is forcibly killed by SIGKILL. Instead, order zerotier after
network.target so it can shutdown gracefully while the network is still
up.

From systemd.special(7):

at shutdown, a unit that is ordered after network.target will be stopped
before the network — to whatever level it might be set up then — is shut
down. It is hence useful when writing service files that require network
access on shutdown, which should order themselves after this target, but
not pull it in