### PR TITLE
Fix permissive filter and check 6plane for outbound packets

### DIFF
--- a/node/Network.cpp
+++ b/node/Network.cpp
@@ -384,14 +384,13 @@ static _doZtFilterResult _doZtFilter(
 					} else if ((etherType == ZT_ETHERTYPE_ARP)&&(frameLen >= 28)) {
 						src.set((const void *)(frameData + 14),4,0);
 					}
-					if (inbound) {
-						if (membership) {
-							if ((src)&&(membership->hasCertificateOfOwnershipFor<InetAddress>(nconf,src)))
-								ownershipVerificationMask |= ZT_RULE_PACKET_CHARACTERISTICS_SENDER_IP_AUTHENTICATED;
-							if (membership->hasCertificateOfOwnershipFor<MAC>(nconf,macSource))
-								ownershipVerificationMask |= ZT_RULE_PACKET_CHARACTERISTICS_SENDER_MAC_AUTHENTICATED;
-						}
-					} else {
+					if (membership) {
+						if ((src)&&(membership->hasCertificateOfOwnershipFor<InetAddress>(nconf,src)))
+							ownershipVerificationMask |= ZT_RULE_PACKET_CHARACTERISTICS_SENDER_IP_AUTHENTICATED;
+						if (membership->hasCertificateOfOwnershipFor<MAC>(nconf,macSource))
+							ownershipVerificationMask |= ZT_RULE_PACKET_CHARACTERISTICS_SENDER_MAC_AUTHENTICATED;
+					}
+					if (!inbound) {
 						for(unsigned int i=0;i<nconf.certificateOfOwnershipCount;++i) {
 							if ((src)&&(nconf.certificatesOfOwnership[i].owns(src)))
 								ownershipVerificationMask |= ZT_RULE_PACKET_CHARACTERISTICS_SENDER_IP_AUTHENTICATED;


### PR DESCRIPTION
As far as I understand it, the changes made in 52a166a to attempt to solve #990 made it so that _any_ NDP emulated address would count as valid source for an inbound packet, regardless of the sender node. 
Also, the output of ``_isV6NDPEmulated`` is only taken into account when marking inbound packets as ``ZT_RULE_PACKET_CHARACTERISTICS_SENDER_IP_AUTHENTICATED``, outbound packets from the 6plane /80 subnet (other than ::1) would not get this this flag and thus dropped by the sender before they can get validated by the reciever as authentitcated ([node/Network.cpp#387](https://github.com/zerotier/ZeroTierOne/compare/master...fakuivan:master#diff-ac28ce1f807c26308d3afa300bc5bee5L387)), I'm not sure the changes I made on that file are valid, so please provide feedback on this if possible.