### PR TITLE
Add support for armv7ve

### DIFF
--- a/make-linux.mk
+++ b/make-linux.mk
@@ -205,6 +205,11 @@ ifeq ($(CC_MACH),armv7hl)
 	override DEFS+=-DZT_NO_TYPE_PUNNING
 	ZT_USE_ARM32_NEON_ASM_CRYPTO=1
 endif
+ifeq ($(CC_MACH),armv7ve)
+        ZT_ARCHITECTURE=3
+        override DEFS+=-DZT_NO_TYPE_PUNNING
+        ZT_USE_ARM32_NEON_ASM_CRYPTO=1
+endif
 ifeq ($(CC_MACH),arm64)
 	ZT_ARCHITECTURE=4
 	override DEFS+=-DZT_NO_TYPE_PUNNING


### PR DESCRIPTION
This commit adds support for ARM armv7ve arch.
The extended version of the ARMv7-A architecture with support for virtualization.