### PR TITLE
Add support for Elbrus-family CPU

### DIFF
--- a/make-linux.mk
+++ b/make-linux.mk
@@ -146,6 +146,9 @@ endif
 ifeq ($(CC_MACH),ppc64el)
 	ZT_ARCHITECTURE=8
 endif
+ifeq ($(CC_MACH),e2k)
+	ZT_ARCHITECTURE=2
+endif
 ifeq ($(CC_MACH),i386)
 	ZT_ARCHITECTURE=1
 endif


### PR DESCRIPTION
I've added lines to enable Elbrus (https://en.wikipedia.org/wiki/Elbrus-8S) microprocessor architecture. No changes in code, only in build procedure (recognize relevant ARCH output).