### PR TITLE
Fix compilation with GCC 10 by providing explicit cast of _bindingCount

### DIFF
--- a/osdep/Binder.hpp
+++ b/osdep/Binder.hpp
@@ -373,9 +373,9 @@ public:
 					}
 #endif // __LINUX__
 					if (_bindingCount < ZT_BINDER_MAX_BINDINGS) {
-						_bindings[_bindingCount].udpSock = udps;
-						_bindings[_bindingCount].tcpListenSock = tcps;
-						_bindings[_bindingCount].address = ii->first;
+						_bindings[(unsigned int)_bindingCount].udpSock = udps;
+						_bindings[(unsigned int)_bindingCount].tcpListenSock = tcps;
+						_bindings[(unsigned int)_bindingCount].address = ii->first;
 						phy.setIfName(udps,(char*)ii->second.c_str(),(int)ii->second.length());
 						++_bindingCount;
 					}


### PR DESCRIPTION
Compilation with GCC 10 fails with the following error:
```
service/../osdep/Binder.hpp: In member function ‘void ZeroTier::Binder::refresh(ZeroTier::Phy<PHY_HANDLER_TYPE>&, unsigned int*, unsigned int, std::vector<ZeroTier::InetAddress>, INTERFACE_CHECKER&)’:
service/../osdep/Binder.hpp:376:30: internal compiler error: unexpected expression ‘(std::__atomic_base<unsigned int>::__int_type)((ZeroTier::Binder*)this)->ZeroTier::Binder::_bindingCount’ of kind implicit_conv_expr
  376 |       _bindings[_bindingCount].udpSock = udps;
      |                              ^
```
Help the compiler by providing an explicit cast to the appropriate type like it is already done in [l. 338 of the same file](https://github.com/zerotier/ZeroTierOne/blob/91b16310ea47a6de96edb488a61494f8ed8c139c/osdep/Binder.hpp#L338).

Fixes: #1213