### PR TITLE
add ports to addresses specified by the bind setting

### DIFF
--- a/osdep/Binder.hpp
+++ b/osdep/Binder.hpp
@@ -316,8 +316,13 @@ public:
 
 #endif
 		} else {
-			for(std::vector<InetAddress>::const_iterator i(explicitBind.begin());i!=explicitBind.end();++i)
-				localIfAddrs.insert(std::pair<InetAddress,std::string>(*i,std::string()));
+			for(std::vector<InetAddress>::const_iterator i(explicitBind.begin());i!=explicitBind.end();++i) {
+				InetAddress ip = InetAddress(*i);
+				for(int x=0;x<(int)portCount;++x) {
+					ip.setPort(ports[x]);
+					localIfAddrs.insert(std::pair<InetAddress,std::string>(ip,std::string()));
+				}
+			}
 		}
 
 		// Default to binding to wildcard if we can't enumerate addresses


### PR DESCRIPTION
This addresses #1252 
Ports are bound to the addresses specified in the bind settings
```
ps -ef | grep zero
  373 root      0:10 /storage/.kodi/addons/service.zerotier-one/bin/zerotier-one


more local.conf
{
  "physical": {
  },
  "virtual": {
  },
  "settings": {
    "bind": [ "192.168.0.123" ]
  }
}


zerotier-cli -j info
{
 "address": "..",
 "clock": ..,
 "config": {
  "physical": {},
  "settings": {
   "allowTcpFallbackRelay": true,
   "bind": [
    "192.168.0.123"
   ],
   "controllerDbPath": null,
   "portMappingEnabled": true,
   "primaryPort": 9993,
   "rabbitmq": null,
   "softwareUpdate": "disable",
   "softwareUpdateChannel": "release"
  },
  "virtual": {}
 },
 "online": true,
 "planetWorldId": ..,
 "planetWorldTimestamp": ..,
 "publicIdentity": "..",
 "tcpFallbackActive": false,
 "version": "1.4.6",
 "versionBuild": 0,
 "versionMajor": 1,
 "versionMinor": 4,
 "versionRev": 6
}


netstat -aptu | grep zero
tcp        0      0 192.168.0.123:23866     0.0.0.0:*               LISTEN      6368/zerotier-one
tcp        0      0 192.168.0.123:23867     0.0.0.0:*               LISTEN      6368/zerotier-one
tcp        0      0 192.168.0.123:9993      0.0.0.0:*               LISTEN      6368/zerotier-one
tcp        0      0 localhost:9993          0.0.0.0:*               LISTEN      6368/zerotier-one
udp        0      0 192.168.0.123:9993      0.0.0.0:*                           6368/zerotier-one
udp        0      0 192.168.0.123:23866     0.0.0.0:*                           6368/zerotier-one
udp        0      0 192.168.0.123:23867     0.0.0.0:*                           6368/zerotier-one
```