### PR TITLE
.NET 4.5 -> 4.8; Rosylnator fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ enc_temp_folder
 /windows/copyutil/bin
 /windows/copyutil/obj
 .vs/
+windows/.editorconfig
+windows/TapDriver6/Win7 Debug/
 
 # *nix/Mac build droppings
 /build-*

--- a/windows/WinUI/AboutView.xaml
+++ b/windows/WinUI/AboutView.xaml
@@ -19,9 +19,9 @@
                     <Run Text="ZeroTier One"/>
                 </Paragraph>
                 <Paragraph TextAlignment="Center">
-                    <Run FontSize="14" Text="Version 1.4.6"/>
+                    <Run FontSize="14" Text="Version 1.6.0"/>
                     <LineBreak/>
-                    <Run FontSize="14" Text="(c) 2011-2019 ZeroTier, Inc."/>
+                    <Run FontSize="14" Text="(c) 2011-2020 ZeroTier, Inc."/>
                     <LineBreak/>
                     <Run FontSize="14" Text="www.zerotier.com"/>
                 </Paragraph>

--- a/windows/WinUI/AboutView.xaml
+++ b/windows/WinUI/AboutView.xaml
@@ -5,31 +5,35 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:WinUI"
         mc:Ignorable="d"
-        Title="AboutView" Height="368.267" Width="300" Icon="ZeroTierIcon.ico">
-	<Grid>
-		<Image x:Name="image" HorizontalAlignment="Center" Height="100" Margin="0,10,0,0" VerticalAlignment="Top" Width="100" Source="ZeroTierIcon.ico"/>
-		<RichTextBox x:Name="richTextBox" HorizontalAlignment="Left" Height="209" Margin="10,123,0,0" VerticalAlignment="Top" Width="275" IsReadOnly="True" IsDocumentEnabled="True" BorderThickness="0" FontSize="18" RenderTransformOrigin="0.506,0.63">
-			<RichTextBox.Resources>
-				<Style TargetType="Hyperlink">
-					<Setter Property="Cursor" Value="Hand" />
-				</Style>
-			</RichTextBox.Resources>
+        Title="AboutView" Height="404.226" Width="286.36" Icon="ZeroTierIcon.ico">
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="42*"/>
+            <ColumnDefinition Width="31*"/>
+        </Grid.ColumnDefinitions>
+        <Image x:Name="image" HorizontalAlignment="Center" Height="100" Margin="96,10,96,0" VerticalAlignment="Top" Width="100" Source="ZeroTierIcon.ico" Grid.ColumnSpan="2"/>
+        <RichTextBox x:Name="richTextBox" HorizontalAlignment="Left" Height="241" Margin="3,120,0,0" VerticalAlignment="Top" Width="275" IsReadOnly="True" IsDocumentEnabled="True" BorderThickness="0" RenderTransformOrigin="0.506,0.63" Grid.ColumnSpan="2" FontSize="16">
+            <RichTextBox.Resources>
+                <Style TargetType="Hyperlink">
+                    <Setter Property="Cursor" Value="Hand" />
+                </Style>
+            </RichTextBox.Resources>
             <FlowDocument>
                 <Paragraph TextAlignment="Center">
                     <Run Text="ZeroTier One"/>
                 </Paragraph>
                 <Paragraph TextAlignment="Center">
-                    <Run FontSize="14" Text="Version 1.6.0"/>
+                    <Run Text="Version 1.6.0"/>
                     <LineBreak/>
-                    <Run FontSize="14" Text="(c) 2011-2020 ZeroTier, Inc."/>
+                    <Run Text="(c) 2011-2020 ZeroTier, Inc."/>
                     <LineBreak/>
-                    <Run FontSize="14" Text="www.zerotier.com"/>
+                    <Run Text="www.zerotier.com"/>
                 </Paragraph>
                 <Paragraph TextAlignment="Center">
-                    <Run FontSize="14" Text="ZeroTier One allows your computer to join virtual networks. Just select &quot;join&quot; and enter a network's 16-digit ID. Each network appears on your computer as a new network port."/>
+                    <Run Text="ZeroTier One allows your computer to join virtual networks. Just select &quot;join&quot; and enter a network's 16-digit ID. Each network appears on your computer as a new network port."/>
                 </Paragraph>
             </FlowDocument>
         </RichTextBox>
 
-	</Grid>
+    </Grid>
 </Window>

--- a/windows/WinUI/App.config
+++ b/windows/WinUI/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/windows/WinUI/App.xaml.cs
+++ b/windows/WinUI/App.xaml.cs
@@ -16,7 +16,7 @@ namespace WinUI
     {
         private TaskbarIcon tb;
 
-        private void InitApplication()
+        internal void InitApplication()
         {
             tb = (TaskbarIcon)FindResource("NotifyIcon");
             tb.Visibility = Visibility.Visible;

--- a/windows/WinUI/CentralAPI.cs
+++ b/windows/WinUI/CentralAPI.cs
@@ -10,14 +10,14 @@ using Newtonsoft.Json;
 
 namespace WinUI
 {
-    class CentralAPI
+    internal sealed class CentralAPI
     {
         private static volatile CentralAPI instance;
-        private static object syncRoot = new Object();
+        private static readonly object syncRoot = new Object();
 
-        private CookieContainer cookieContainer;
-        private HttpClientHandler clientHandler;
-        private HttpClient client;
+        private readonly CookieContainer cookieContainer;
+        private readonly HttpClientHandler clientHandler;
+        private readonly HttpClient client;
 
         private CentralServer server;
         public CentralServer Central
@@ -53,8 +53,6 @@ namespace WinUI
             }
         }
 
-
-
         private CentralAPI()
         {
 #if DEBUG
@@ -76,14 +74,7 @@ namespace WinUI
                 byte[] tmp = File.ReadAllBytes(centralConfigPath);
                 string json = Encoding.UTF8.GetString(tmp).Trim();
                 CentralServer ctmp = JsonConvert.DeserializeObject<CentralServer>(json);
-                if (ctmp != null)
-                {
-                    Central = ctmp;
-                } 
-                else
-                {
-                    Central = new CentralServer();
-                }
+                Central = ctmp ?? new CentralServer();
             }
             else
             {
@@ -93,10 +84,7 @@ namespace WinUI
 
         public bool HasAccessToken()
         {
-            if (Central == null)
-                return false;
-
-            return !string.IsNullOrEmpty(Central.APIKey);
+            return Central == null ? false : !string.IsNullOrEmpty(Central.APIKey);
         }
 
         private string ZeroTierDir()
@@ -137,21 +125,21 @@ namespace WinUI
             string postURL = Central.ServerURL + "/api/_auth/local";
             CentralLogin login = new CentralLogin(email, password, isNewUser);
             var content = new StringContent(JsonConvert.SerializeObject(login), Encoding.UTF8, "application/json");
-            HttpResponseMessage response = await client.PostAsync(postURL, content);
+            HttpResponseMessage response = await client.PostAsync(postURL, content).ConfigureAwait(true);
 
             if (!response.IsSuccessStatusCode)
             {
                 return false;
             }
 
-            string resContent = await response.Content.ReadAsStringAsync();
+            string resContent = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
 
             CentralUser user = JsonConvert.DeserializeObject<CentralUser>(resContent);
 
             if (user.Tokens.Count == 0)
             {
                 // create token
-                user = await CreateAuthToken(user);
+                user = await CreateAuthToken(user).ConfigureAwait(true);
             }
 
             Central.APIKey = user.Tokens[0];
@@ -165,7 +153,7 @@ namespace WinUI
         public async Task<CentralUser> CreateAuthToken(CentralUser user)
         {
             string randomTokenURL = Central.ServerURL + "/api/randomToken";
-            HttpResponseMessage response = await client.GetAsync(randomTokenURL);
+            HttpResponseMessage response = await client.GetAsync(randomTokenURL).ConfigureAwait(true);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -173,7 +161,7 @@ namespace WinUI
                 return null;
             }
 
-            string resContent = await response.Content.ReadAsStringAsync();
+            string resContent = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
 
             CentralToken t = JsonConvert.DeserializeObject<CentralToken>(resContent);
 
@@ -183,7 +171,7 @@ namespace WinUI
 
             string postURL = Central.ServerURL + "/api/user/" + user.Id;
             var postContent = new StringContent(tokenObj, Encoding.UTF8, "application/json");
-            response = await client.PostAsync(postURL, postContent);
+            response = await client.PostAsync(postURL, postContent).ConfigureAwait(true);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -191,17 +179,15 @@ namespace WinUI
                 return null;
             }
 
-            resContent = await response.Content.ReadAsStringAsync();
-            user = JsonConvert.DeserializeObject<CentralUser>(resContent);
-
-            return user;
+            resContent = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+            return JsonConvert.DeserializeObject<CentralUser>(resContent);
         }
 
         public async Task<List<CentralNetwork>> GetNetworkList()
         {
             string networkURL = Central.ServerURL + "/api/network";
 
-            HttpResponseMessage response = await client.GetAsync(networkURL);
+            HttpResponseMessage response = await client.GetAsync(networkURL).ConfigureAwait(true);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -209,7 +195,7 @@ namespace WinUI
                 return new List<CentralNetwork>();
             }
 
-            string resContent = await response.Content.ReadAsStringAsync();
+            string resContent = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
 
             List<CentralNetwork> networkList = JsonConvert.DeserializeObject<List<CentralNetwork>>(resContent);
 
@@ -219,19 +205,23 @@ namespace WinUI
         public async Task<CentralNetwork> CreateNewNetwork()
         {
             string networkURL = Central.ServerURL + "/api/network?easy=1";
-            CentralNetwork network = new CentralNetwork();
-            network.Config = new CentralNetwork.CentralNetworkConfig();
-            network.Config.Name = NetworkNameGenerator.GenerateName();
+            CentralNetwork network = new CentralNetwork
+            {
+                Config = new CentralNetwork.CentralNetworkConfig
+                {
+                    Name = NetworkNameGenerator.GenerateName()
+                }
+            };
             string jsonNetwork = JsonConvert.SerializeObject(network);
             var postContent = new StringContent(jsonNetwork, Encoding.UTF8, "application/json");
-            HttpResponseMessage response = await client.PostAsync(networkURL, postContent);
+            HttpResponseMessage response = await client.PostAsync(networkURL, postContent).ConfigureAwait(true);
 
             if (!response.IsSuccessStatusCode)
             {
                 return null;
             }
 
-            string resContent = await response.Content.ReadAsStringAsync();
+            string resContent = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
 
             CentralNetwork newNetwork = JsonConvert.DeserializeObject<CentralNetwork>(resContent);
 
@@ -240,17 +230,12 @@ namespace WinUI
 
         public async Task<bool> AuthorizeNode(string nodeAddress, string networkId)
         {
-            string json = "{ \"config\": { \"authorized\": true } }";
+            const string json = "{ \"config\": { \"authorized\": true } }";
             string postURL = Central.ServerURL + "/api/network/" + networkId + "/member/" + nodeAddress;
             var postContent = new StringContent(json, Encoding.UTF8, "application/json");
-            HttpResponseMessage response = await client.PostAsync(postURL, postContent);
+            HttpResponseMessage response = await client.PostAsync(postURL, postContent).ConfigureAwait(true);
 
-            if (response.IsSuccessStatusCode)
-            {
-                return true;
-            }
-
-            return false;
+            return response.IsSuccessStatusCode;
         }
     }
 }

--- a/windows/WinUI/CentralLogin.cs
+++ b/windows/WinUI/CentralLogin.cs
@@ -7,10 +7,8 @@ using Newtonsoft.Json;
 
 namespace WinUI
 {
-    class CentralLogin
+    internal class CentralLogin
     {
-
-
         public CentralLogin(string email, string password, bool isNew)
         {
             Login = email;

--- a/windows/WinUI/CentralNetwork.cs
+++ b/windows/WinUI/CentralNetwork.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 
 namespace WinUI
 {
-    class CentralNetwork
+    internal class CentralNetwork
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/windows/WinUI/CentralServer.cs
+++ b/windows/WinUI/CentralServer.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 
 namespace WinUI
 {
-    class CentralServer
+    internal class CentralServer
     {
         public CentralServer()
         {

--- a/windows/WinUI/CentralToken.cs
+++ b/windows/WinUI/CentralToken.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 
 namespace WinUI
 {
-    class CentralToken
+    internal class CentralToken
     {
         [JsonProperty("token")]
         public string Token { get; set; }

--- a/windows/WinUI/CentralUser.cs
+++ b/windows/WinUI/CentralUser.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 
 namespace WinUI
 {
-    class CentralUser
+    internal class CentralUser
     {
         public class CentralGlobalPermissions
         {

--- a/windows/WinUI/ISwitchable.cs
+++ b/windows/WinUI/ISwitchable.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace WinUI
 {
-    interface ISwitchable
+    internal interface ISwitchable
     {
         void UtilizeState(object state);
     }

--- a/windows/WinUI/JoinNetworkView.xaml.cs
+++ b/windows/WinUI/JoinNetworkView.xaml.cs
@@ -20,8 +20,8 @@ namespace WinUI
     /// </summary>
     public partial class JoinNetworkView : Window
     {
-        Regex charRegex = new Regex("[0-9a-fxA-FX]");
-        Regex wholeStringRegex = new Regex("^[0-9a-fxA-FX]+$");
+        private readonly Regex charRegex = new Regex("[0-9a-fxA-FX]");
+        private readonly Regex wholeStringRegex = new Regex("^[0-9a-fxA-FX]+$");
 
         public JoinNetworkView()
         {
@@ -35,14 +35,7 @@ namespace WinUI
         {
             e.Handled = !charRegex.IsMatch(e.Text);
 
-            if ( (joinNetworkBox.Text.Length + e.Text.Length) == 16)
-            {
-                joinButton.IsEnabled = true;
-            }
-            else
-            {
-                joinButton.IsEnabled = false;
-            }
+            joinButton.IsEnabled = (joinNetworkBox.Text.Length + e.Text.Length) == 16;
         }
 
         private void joinNetworkBox_OnKeyDown(object sender, KeyEventArgs e)
@@ -57,14 +50,7 @@ namespace WinUI
             }
             else if (e.Key == Key.Delete || e.Key == Key.Back)
             {
-                if ((joinNetworkBox.Text.Length - 1) == 16)
-                {
-                    joinButton.IsEnabled = true;
-                }
-                else
-                {
-                    joinButton.IsEnabled = false;
-                }
+                joinButton.IsEnabled = (joinNetworkBox.Text.Length - 1) == 16;
             }
             else
             {
@@ -109,7 +95,6 @@ namespace WinUI
 
         private void onCopyCut(object sender, DataObjectCopyingEventArgs e)
         {
-            
         }
 
         private void joinButton_Click(object sender, RoutedEventArgs e)

--- a/windows/WinUI/NetworkInfoView.xaml.cs
+++ b/windows/WinUI/NetworkInfoView.xaml.cs
@@ -40,7 +40,6 @@ namespace WinUI
 
         private void UpdateNetworkData()
         {
-
             if (this.networkId.Text != network.NetworkId)
                 this.networkId.Text = network.NetworkId;
 
@@ -80,21 +79,18 @@ namespace WinUI
             this.allowGlobal.IsChecked = network.AllowGlobal;
             this.allowManaged.IsChecked = network.AllowManaged;
 
-						this.connectedCheckBox.Checked -= connectedCheckBox_Checked;
-						this.connectedCheckBox.Unchecked -= connectedCheckbox_Unchecked;
+            this.connectedCheckBox.Checked -= connectedCheckBox_Checked;
+            this.connectedCheckBox.Unchecked -= connectedCheckbox_Unchecked;
 
             this.connectedCheckBox.IsChecked = network.IsConnected;
 
-						this.connectedCheckBox.Checked += connectedCheckBox_Checked;
-						this.connectedCheckBox.Unchecked += connectedCheckbox_Unchecked;
-				}
+            this.connectedCheckBox.Checked += connectedCheckBox_Checked;
+            this.connectedCheckBox.Unchecked += connectedCheckbox_Unchecked;
+        }
 
         public bool HasNetwork(ZeroTierNetwork network)
         {
-            if (this.network.NetworkId.Equals(network.NetworkId))
-                return true;
-
-            return false;
+            return this.network.NetworkId.Equals(network.NetworkId);
         }
 
         public void SetNetworkInfo(ZeroTierNetwork network)
@@ -112,7 +108,6 @@ namespace WinUI
 
         private void AllowManaged_CheckStateChanged(object sender, RoutedEventArgs e)
         {
-            CheckBox cb = sender as CheckBox;
             APIHandler.Instance.JoinNetwork(this.Dispatcher, network.NetworkId,
                 allowManaged.IsChecked ?? false,
                 allowGlobal.IsChecked ?? false,
@@ -121,7 +116,6 @@ namespace WinUI
 
         private void AllowGlobal_CheckStateChanged(object sender, RoutedEventArgs e)
         {
-            CheckBox cb = sender as CheckBox;
             APIHandler.Instance.JoinNetwork(this.Dispatcher, network.NetworkId,
                 allowManaged.IsChecked ?? false,
                 allowGlobal.IsChecked ?? false,
@@ -130,7 +124,6 @@ namespace WinUI
 
         private void AllowDefault_CheckStateChanged(object sender, RoutedEventArgs e)
         {
-            CheckBox cb = sender as CheckBox;
             APIHandler.Instance.JoinNetwork(this.Dispatcher, network.NetworkId,
                 allowManaged.IsChecked ?? false,
                 allowGlobal.IsChecked ?? false,

--- a/windows/WinUI/NetworkListView.xaml.cs
+++ b/windows/WinUI/NetworkListView.xaml.cs
@@ -26,8 +26,8 @@ namespace WinUI
     /// </summary>
     public partial class NetworkListView : Window
     {
-        Regex charRegex = new Regex("[0-9a-fxA-FX]");
-        Regex wholeStringRegex = new Regex("^[0-9a-fxA-FX]+$");
+        private readonly Regex charRegex = new Regex("[0-9a-fxA-FX]");
+        private readonly Regex wholeStringRegex = new Regex("^[0-9a-fxA-FX]+$");
 
         public NetworkListView()
         {
@@ -36,10 +36,6 @@ namespace WinUI
             Closed += onClosed;
 
             NetworkMonitor.Instance.SubscribeNetworkUpdates(updateNetworks);
-        }
-
-        ~NetworkListView()
-        {
         }
 
         protected override void OnClosing(CancelEventArgs e)
@@ -57,10 +53,7 @@ namespace WinUI
         {
             if (networks != null)
             {
-                networksPage.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(() =>
-                {
-                    networksPage.setNetworks(networks);
-                }));
+                networksPage.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(() => networksPage.setNetworks(networks)));
             }
         }
 

--- a/windows/WinUI/NetworkMonitor.cs
+++ b/windows/WinUI/NetworkMonitor.cs
@@ -8,20 +8,19 @@ using System.Threading.Tasks;
 
 namespace WinUI
 {
-    class NetworkMonitor
+    internal sealed class NetworkMonitor
     {
         public delegate void NetworkListCallback(List<ZeroTierNetwork> networks);
         public delegate void StatusCallback(ZeroTierStatus status);
 
-        private Thread runThread;
+        private readonly Thread runThread;
         private NetworkListCallback _nwCb;
         private StatusCallback _stCb;
-
 
         private List<ZeroTierNetwork> _knownNetworks = new List<ZeroTierNetwork>();
 
         private static NetworkMonitor instance;
-        private static object syncRoot = new object();
+        private static readonly object syncRoot = new object();
 
         public static NetworkMonitor Instance
         {
@@ -59,7 +58,7 @@ namespace WinUI
         {
             String dataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "\\ZeroTier\\One";
             String dataFile = Path.Combine(dataPath, "networks.dat");
-            
+
             if (File.Exists(dataFile))
             {
                 List<ZeroTierNetwork> netList;
@@ -102,10 +101,10 @@ namespace WinUI
 
         private void apiNetworkCallback(List<ZeroTierNetwork> networks)
         {
-						if (networks == null)
-						{
-								return;
-						}
+            if (networks == null)
+            {
+                return;
+            }
 
             lock (_knownNetworks)
             {
@@ -113,14 +112,7 @@ namespace WinUI
 
                 foreach (ZeroTierNetwork n in _knownNetworks)
                 {
-                    if (networks.Contains(n))
-                    {
-                        n.IsConnected = true;
-                    }
-                    else
-                    {
-                        n.IsConnected = false;
-                    }
+                    n.IsConnected = networks.Contains(n);
                 }
 
                 _knownNetworks.Sort();
@@ -154,9 +146,9 @@ namespace WinUI
             }
             catch (Exception e)
             {
-                Console.WriteLine("Monitor Thread Exception: " + "\n" + e.StackTrace);
+                Console.WriteLine("Monitor Thread Exception: \n" + e.StackTrace);
             }
-			Console.WriteLine("Monitor Thread Ended");
+            Console.WriteLine("Monitor Thread Ended");
         }
 
         public void SubscribeStatusUpdates(StatusCallback cb)
@@ -181,7 +173,7 @@ namespace WinUI
 
         public void RemoveNetwork(String networkID)
         {
-            lock(_knownNetworks)
+            lock (_knownNetworks)
             {
                 foreach (ZeroTierNetwork n in _knownNetworks)
                 {

--- a/windows/WinUI/NetworkNameGenerator.cs
+++ b/windows/WinUI/NetworkNameGenerator.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace WinUI
 {
-    class NetworkNameGenerator
+    internal static class NetworkNameGenerator
     {
         public static string GenerateName()
         {
@@ -16,7 +16,7 @@ namespace WinUI
             return FIRST[firstIndex] + "_" + SECOND[secondIndex];
         }
 
-        private static string[] FIRST =
+        private static readonly string[] FIRST =
         {
               "admiring",
               "adoring",
@@ -74,7 +74,7 @@ namespace WinUI
               "trusting"
         };
 
-        private static string[] SECOND =
+        private static readonly string[] SECOND =
         {
             // constructed telephone-like devices in 1854
             "meucci",

--- a/windows/WinUI/NetworksPage.xaml.cs
+++ b/windows/WinUI/NetworksPage.xaml.cs
@@ -71,7 +71,7 @@ namespace WinUI
         private NetworkInfoView ChildWithNetwork(ZeroTierNetwork network)
         {
             List<NetworkInfoView> list = wrapPanel.Children.OfType<NetworkInfoView>().ToList();
-           
+
             foreach (NetworkInfoView view in list)
             {
                 if (view.HasNetwork(network))

--- a/windows/WinUI/PeersPage.xaml.cs
+++ b/windows/WinUI/PeersPage.xaml.cs
@@ -20,7 +20,7 @@ namespace WinUI
     /// </summary>
     public partial class PeersPage : UserControl
     {
-        private List<ZeroTierPeer> peersList = new List<ZeroTierPeer>();
+        private readonly List<ZeroTierPeer> peersList = new List<ZeroTierPeer>();
 
         public PeersPage()
         {
@@ -34,13 +34,12 @@ namespace WinUI
             if (list == null)
                 return;
 
-            
-            foreach(ZeroTierPeer p in list)
+            foreach (ZeroTierPeer p in list)
             {
                 ZeroTierPeer curPeer = peersList.Find(peer => peer.Equals(p));
                 if (curPeer == null)
                 {
-                    peersList.Add(p);                    
+                    peersList.Add(p);
                 }
                 else
                 {

--- a/windows/WinUI/PreferencesView.xaml.cs
+++ b/windows/WinUI/PreferencesView.xaml.cs
@@ -21,16 +21,15 @@ namespace WinUI
     public partial class PreferencesView : Window
     {
         public static string AppName = "ZeroTier One";
-        private RegistryKey rk = Registry.CurrentUser.OpenSubKey("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run", true);
-        private string AppLocation = System.Reflection.Assembly.GetExecutingAssembly().Location;
+        private readonly RegistryKey rk = Registry.CurrentUser.OpenSubKey("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run", true);
+        private readonly string AppLocation = System.Reflection.Assembly.GetExecutingAssembly().Location;
         public PreferencesView()
         {
             InitializeComponent();
 
-
             string keyValue = rk.GetValue(AppName) as string;
 
-            if (keyValue != null && keyValue.Equals(AppLocation))
+            if (keyValue?.Equals(AppLocation) == true)
             {
                 startupCheckbox.IsChecked = true;
             }
@@ -47,9 +46,11 @@ namespace WinUI
             if (api.Central.ServerURL != CentralInstanceTextBox.Text ||
                 api.Central.APIKey != APIKeyTextBox.Text)
             {
-                CentralServer newServer = new CentralServer();
-                newServer.ServerURL = CentralInstanceTextBox.Text;
-                newServer.APIKey = APIKeyTextBox.Text;
+                CentralServer newServer = new CentralServer
+                {
+                    ServerURL = CentralInstanceTextBox.Text,
+                    APIKey = APIKeyTextBox.Text
+                };
 
                 api.Central = newServer;
             }
@@ -62,7 +63,7 @@ namespace WinUI
             {
                 string keyValue = rk.GetValue(AppName) as string;
 
-                if (keyValue != null && keyValue.Equals(AppLocation))
+                if (keyValue?.Equals(AppLocation) == true)
                 {
                     rk.DeleteValue(AppName);
                 }

--- a/windows/WinUI/Properties/AssemblyInfo.cs
+++ b/windows/WinUI/Properties/AssemblyInfo.cs
@@ -8,11 +8,11 @@ using System.Windows;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("ZeroTier One")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("Windows GUI for ZeroTier")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("ZeroTier, Inc")]
 [assembly: AssemblyProduct("ZeroTier One")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright (c) 2020 ZeroTier, Inc.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -49,6 +49,6 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.6.0.0")]
+[assembly: AssemblyFileVersion("1.6.0.0")]
 [assembly: NeutralResourcesLanguageAttribute("en-US")]

--- a/windows/WinUI/Properties/AssemblyInfo.cs
+++ b/windows/WinUI/Properties/AssemblyInfo.cs
@@ -30,16 +30,14 @@ using System.Windows;
 
 //[assembly: NeutralResourcesLanguage("en-US", UltimateResourceFallbackLocation.Satellite)]
 
-
 [assembly: ThemeInfo(
     ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
-    //(used if a resource is not found in the page, 
-    // or application resource dictionaries)
+                                     //(used if a resource is not found in the page, 
+                                     // or application resource dictionaries)
     ResourceDictionaryLocation.SourceAssembly //where the generic resource dictionary is located
-    //(used if a resource is not found in the page, 
-    // app, or any theme specific resource dictionaries)
+                                              //(used if a resource is not found in the page, 
+                                              // app, or any theme specific resource dictionaries)
 )]
-
 
 // Version information for an assembly consists of the following four values:
 //

--- a/windows/WinUI/Properties/Resources.Designer.cs
+++ b/windows/WinUI/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace WinUI.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/windows/WinUI/Properties/Settings.Designer.cs
+++ b/windows/WinUI/Properties/Settings.Designer.cs
@@ -8,21 +8,17 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace WinUI.Properties
-{
-
-
+namespace WinUI.Properties {
+    
+    
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "11.0.0.0")]
-    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase
-    {
-
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.7.0.0")]
+    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
+        
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
-
-        public static Settings Default
-        {
-            get
-            {
+        
+        public static Settings Default {
+            get {
                 return defaultInstance;
             }
         }

--- a/windows/WinUI/WinUI.csproj
+++ b/windows/WinUI/WinUI.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,11 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WinUI</RootNamespace>
     <AssemblyName>ZeroTier One</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
-    <ExpressionBlendVersion>5.0.40218.0</ExpressionBlendVersion>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
@@ -30,6 +29,7 @@
     <ApplicationVersion>1.0.0.0</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -70,9 +70,8 @@
       <HintPath>..\packages\Hardcodet.NotifyIcon.Wpf.1.0.8\lib\net45\Hardcodet.Wpf.TaskbarNotification.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="PresentationUI, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="ReachFramework" />
@@ -260,7 +259,6 @@
     <None Include="Resources\ZeroTierIcon.ico" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\Expression\Blend\.NETFramework\v4.5\Microsoft.Expression.Blend.WPF.targets" />
   <PropertyGroup>
     <PostBuildEvent>copy "$(SolutionDir)\copyutil\bin\$(ConfigurationName)\copyutil.exe" "$(ProjectDir)\$(OutDir)\copyutil.exe"</PostBuildEvent>
   </PropertyGroup>

--- a/windows/WinUI/ZeroTierNetwork.cs
+++ b/windows/WinUI/ZeroTierNetwork.cs
@@ -177,7 +177,8 @@ namespace WinUI
         }
 
         [JsonProperty("nwid")]
-        public string NetworkId {
+        public string NetworkId
+        {
             get
             {
                 return networkId;
@@ -229,7 +230,6 @@ namespace WinUI
                 networkStatus = value;
                 NotifyPropertyChanged();
             }
-
         }
 
         [JsonProperty("type")]
@@ -413,7 +413,7 @@ namespace WinUI
                 NotifyPropertyChanged();
             }
         }
-        
+
         public bool IsConnected
         {
             get
@@ -431,26 +431,15 @@ namespace WinUI
         {
             get
             {
-
-                if (NetworkName != null && NetworkName.Length > 0)
-                {
-                    return NetworkId + " (" + NetworkName + ")";
-                }
-                else
-                {
-                    return NetworkId;
-                }
+                return NetworkName?.Length > 0 ? NetworkId + " (" + NetworkName + ")" : NetworkId;
             }
         }
 
         public bool Equals(ZeroTierNetwork network)
         {
-            if (NetworkId == null || network == null)
-                return false;
-
-            return NetworkId.Equals(network.NetworkId);
+            return NetworkId == null || network == null ? false : NetworkId.Equals(network.NetworkId);
         }
-        
+
         public int CompareTo(ZeroTierNetwork network)
         {
             if (NetworkId == null || network == null)
@@ -463,18 +452,14 @@ namespace WinUI
             {
                 return 1;
             }
-            else if (thisNwid < otherNwid)
-            {
-                return -1;
-            }
             else
             {
-                return 0;
+                return thisNwid < otherNwid ? -1 : 0;
             }
         }
     }
 
-     public class NetworkEqualityComparer : IEqualityComparer<ZeroTierNetwork>
+    public class NetworkEqualityComparer : IEqualityComparer<ZeroTierNetwork>
     {
         public bool Equals(ZeroTierNetwork lhs, ZeroTierNetwork rhs)
         {

--- a/windows/WinUI/ZeroTierPeer.cs
+++ b/windows/WinUI/ZeroTierPeer.cs
@@ -33,7 +33,7 @@ namespace WinUI
 
         private Int64 _lastMulticast;
         [JsonProperty("lastMulticastFrame")]
-        public Int64 LastMulticastFrame 
+        public Int64 LastMulticastFrame
         {
             get
             {
@@ -66,10 +66,7 @@ namespace WinUI
         {
             get
             {
-                if (Version == "-1.-1.-1")
-                    return "-";
-                else
-                    return Version;
+                return Version == "-1.-1.-1" ? "-" : Version;
             }
         }
 
@@ -87,7 +84,7 @@ namespace WinUI
             get
             {
                 string pathStr = "";
-                foreach(ZeroTierPeerPhysicalPath path in Paths)
+                foreach (ZeroTierPeerPhysicalPath path in Paths)
                 {
                     pathStr += path.Address + "\n";
                 }

--- a/windows/WinUI/packages.config
+++ b/windows/WinUI/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Hardcodet.NotifyIcon.Wpf" version="1.0.8" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
 </packages>

--- a/windows/ZeroTierOne.sln
+++ b/windows/ZeroTierOne.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28010.2050
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30503.244
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ZeroTierOne", "ZeroTierOne\ZeroTierOne.vcxproj", "{B00A4957-5977-4AC1-9EF4-571DC27EADA2}"
 EndProject
@@ -13,6 +13,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WinUI", "WinUI\WinUI.csproj
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "copyutil", "copyutil\copyutil.csproj", "{6D27214A-087B-4484-B898-AD2A13FA3B9E}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{0A421F01-7BEC-4911-8B90-9FCB2BA6BC94}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/windows/copyutil/copyutil.csproj
+++ b/windows/copyutil/copyutil.csproj
@@ -47,6 +47,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\.editorconfig">
+      <Link>.editorconfig</Link>
+    </None>
     <None Include="App.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
1. Removed a dependency in the project file for the deprecated Expressions product; it wouldn't load otherwise.
2. Set to use .NET 4.8 instead of .NET 4.5; this still covers Win Server 2012 R2 & Windows 7 SP1, while allowing C# 7 and older code.
3. Used https://github.com/JosefPihrt/Roslynator to apply assorted fixes. Went from over 100 possible fixes to 4.

@laduke you were asking about the API hook a few weeks ago; at one point in this process, the API variable was being declared as unused. Switching that to internal seemed to resolve that error.
