### PR TITLE
FreeBSD ARMv6, ARMv7, and Aarch64 support

### DIFF
--- a/make-bsd.mk
+++ b/make-bsd.mk
@@ -80,16 +80,16 @@ ifeq ($(CC_MACH),armv6kz)
 endif
 ifeq ($(CC_MACH),armv7)
 	ZT_ARCHITECTURE=3
-	override DEFS+=-DZT_NO_TYPE_PUNNING
+	override DEFS+=-DZT_NO_TYPE_PUNNING -DZT_AES_NO_ACCEL
 	ZT_USE_ARM32_NEON_ASM_SALSA2012=1
 endif
 ifeq ($(CC_MACH),arm64)
 	ZT_ARCHITECTURE=4
-	override DEFS+=-DZT_NO_TYPE_PUNNING
+	override DEFS+=-DZT_NO_TYPE_PUNNING -march=armv8-a+crypto
 endif
 ifeq ($(CC_MACH),aarch64)
 	ZT_ARCHITECTURE=4
-	override DEFS+=-DZT_NO_TYPE_PUNNING
+	override DEFS+=-DZT_NO_TYPE_PUNNING -march=armv8-a+crypto
 endif
 ifeq ($(CC_MACH),mipsel)
 	ZT_ARCHITECTURE=5
@@ -124,6 +124,7 @@ ifeq ($(ZT_USE_ARM32_NEON_ASM_SALSA2012),1)
 	override DEFS+=-DZT_USE_ARM32_NEON_ASM_SALSA2012
 	override CORE_OBJS+=ext/arm32-neon-salsa2012-asm/salsa2012.o
 	override ASFLAGS+=-meabi=5
+	override LDFLAGS+=-Wl,-z,notext
 endif
 
 override DEFS+=-DZT_BUILD_PLATFORM=$(ZT_BUILD_PLATFORM) -DZT_BUILD_ARCHITECTURE=$(ZT_ARCHITECTURE) -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\""

--- a/node/Utils.cpp
+++ b/node/Utils.cpp
@@ -50,6 +50,38 @@
 #include <asm/hwcap.h>
 #endif
 
+#if defined(__FreeBSD__)
+#include <elf.h>
+#include <sys/auxv.h>
+static inline long getauxval(int caps) {
+	long hwcaps = 0;
+	elf_aux_info(caps, &hwcaps, sizeof(hwcaps));
+	return hwcaps;
+}
+#endif
+
+// If these are not even defined, then they're not supported at all
+#ifndef HWCAP_AES
+#define HWCAP_AES 0
+#endif
+
+#ifndef HWCAP_CRC32
+#define HWCAP_CRC32 0
+#endif
+
+#ifndef HWCAP_PMULL
+#define HWCAP_PMULL 0
+#endif
+
+#ifndef HWCAP_SHA1
+#define HWCAP_SHA1 0
+#endif
+
+#ifndef HWCAP_SHA2
+#define HWCAP_SHA2 0
+#endif
+
+
 namespace ZeroTier {
 
 const uint64_t Utils::ZERO256[4] = {0ULL,0ULL,0ULL,0ULL};


### PR DESCRIPTION
Fixing builds on FreeBSD

* Added linker flags to fix arm32-neon-salsa2012-asm
* Added ZT_AES_NO_ACCEL to ARMv7 (this could possibly be improved, but I think it'll require changes in the FreeBSD source tree)
* Added -march=armv8-a+crypto to ARM64 (without this, clang refused to recognize crypto intrinsic)
* Added a shim for getauxval since this isn't available on FreeBSD
* The HWCAP defines and detection could probably be cleaned up / improved, but this at least works