### PR TITLE
blacklist wg# (WireGuard) interfaces by default

### DIFF
--- a/service/OneService.cpp
+++ b/service/OneService.cpp
@@ -3017,6 +3017,7 @@ public:
 		if ((ifname[0] == 'z') && (ifname[1] == 't')) return false; // sanity check: zt#
 		if ((ifname[0] == 't') && (ifname[1] == 'u') && (ifname[2] == 'n')) return false; // tun# is probably an OpenVPN tunnel or similar
 		if ((ifname[0] == 't') && (ifname[1] == 'a') && (ifname[2] == 'p')) return false; // tap# is probably an OpenVPN tunnel or similar
+		if ((ifname[0] == 'w') && (ifname[1] == 'g')) return false; // wg# is probably a WireGuard tunnel or similar
 #endif
 
 #ifdef __APPLE__
@@ -3025,6 +3026,7 @@ public:
 		if ((ifname[0] == 'z') && (ifname[1] == 't')) return false; // sanity check: zt#
 		if ((ifname[0] == 't') && (ifname[1] == 'u') && (ifname[2] == 'n')) return false; // tun# is probably an OpenVPN tunnel or similar
 		if ((ifname[0] == 't') && (ifname[1] == 'a') && (ifname[2] == 'p')) return false; // tap# is probably an OpenVPN tunnel or similar
+		if ((ifname[0] == 'w') && (ifname[1] == 'g')) return false; // wg# is probably a WireGuard tunnel or similar
 		if ((ifname[0] == 'u') && (ifname[1] == 't') && (ifname[2] == 'u') && (ifname[3] == 'n')) return false; // ... as is utun#
 #endif
 


### PR DESCRIPTION
This adds wg# interfaces to the default WAN blacklist for certain OSes as tun#, tap#, and of course zt# are already blacklisted by default.