### PR TITLE
Initial docker release image tooling

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,22 @@
+# vim: ft=dockerfile
+
+FROM debian:buster as stage
+
+ARG PACKAGE_BASEURL=https://download.zerotier.com/debian/buster/pool/main/z/zerotier-one/
+ARG ARCH=amd64
+ARG VERSION
+
+RUN apt-get update -qq && apt-get install curl -y
+RUN curl -sSL -o zerotier-one.deb "${PACKAGE_BASEURL}/zerotier-one_${VERSION}_${ARCH}.deb"
+
+FROM debian:buster
+
+COPY --from=stage zerotier-one.deb .
+
+RUN dpkg -i zerotier-one.deb && rm -f zerotier-one.deb
+RUN echo "${VERSION}" >/etc/zerotier-version
+
+COPY entrypoint.sh.release /entrypoint.sh
+RUN chmod 755 /entrypoint.sh
+
+CMD /entrypoint.sh

--- a/entrypoint.sh.release
+++ b/entrypoint.sh.release
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+grepzt() {
+  (find /proc -name exe | xargs -I{} readlink {}) 2>/dev/null | grep -q zerotier-one
+  return $?
+}
+
+echo "starting zerotier"
+setsid /usr/sbin/zerotier-one &
+
+while ! grepzt
+do
+  echo "zerotier hasn't started, waiting a second"
+  sleep 1
+done
+
+echo "joining networks"
+
+for i in "$@"
+do
+  echo "joining $i"
+
+  while ! zerotier-cli join "$i"
+  do 
+    echo "joining $i failed; trying again in 1s"
+    sleep 1
+  done
+done
+
+sleep infinity


### PR DESCRIPTION
Here's some docker release tooling!

I'll document it more once it boils down to something we want to use, but run it like so:

```
docker build -f Dockerfile.release --build-arg VERSION=1.6.4 -t zerotier .
docker run -it --privileged -v zt:/var/lib/zerotier --device /dev/net/tun zerotier <networkA> <networkB>
```

Identities probably need to be resolved still in a cleaner way, but you should
be able to mount them into that volume and it should work.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>
