### PR TITLE
Show the port number which is not able to connect

### DIFF
--- a/service/OneService.cpp
+++ b/service/OneService.cpp
@@ -676,6 +676,9 @@ public:
 			readLocalSettings();
 			applyLocalConfig();
 
+			// Save original port number to show it if bind error
+			const int _configuredPort = _primaryPort;
+
 			// Make sure we can use the primary port, and hunt for one if configured to do so
 			const int portTrials = (_primaryPort == 0) ? 256 : 1; // if port is 0, pick random
 			for(int k=0;k<portTrials;++k) {
@@ -693,7 +696,7 @@ public:
 			if (_ports[0] == 0) {
 				Mutex::Lock _l(_termReason_m);
 				_termReason = ONE_UNRECOVERABLE_ERROR;
-				_fatalErrorMessage = "cannot bind to local control interface port";
+				_fatalErrorMessage = std::string("cannot bind to local control interface port ")+std::to_string(_configuredPort);
 				return _termReason;
 			}
 


### PR DESCRIPTION
For users that do not know/remember the default port and for better error explanation I add to the error message the port number to know which is the port that bind process is not able to get.