### PR TITLE
Fix compilation error on MSVC and refactor code

### DIFF
--- a/include/ZeroTierOne.h
+++ b/include/ZeroTierOne.h
@@ -23,6 +23,7 @@
 
 // For the struct sockaddr_storage structure
 #if defined(_WIN32) || defined(_WIN64)
+#define NOMINMAX
 #include <WinSock2.h>
 #include <WS2tcpip.h>
 #include <Windows.h>

--- a/node/Bond.cpp
+++ b/node/Bond.cpp
@@ -977,18 +977,17 @@ void Bond::curateBond(const int64_t now, bool rebuildBond)
 
 void Bond::estimatePathQuality(const int64_t now)
 {
-	char pathStr[128];
 	uint32_t totUserSpecifiedLinkSpeed = 0;
 	if (_numBondedPaths) { // Compute relative user-specified speeds of links
-		for(unsigned int i=0;i<_numBondedPaths;++i) {
-			SharedPtr<Link> link =RR->bc->getLinkBySocket(_policyAlias, _paths[i]->localSocket());
+		for (unsigned int i=0; i<_numBondedPaths; ++i) {
 			if (_paths[i] && _paths[i]->allowed()) {
+				SharedPtr<Link> link = RR->bc->getLinkBySocket(_policyAlias, _paths[i]->localSocket());
 				totUserSpecifiedLinkSpeed += link->speed();
 			}
 		}
-		for(unsigned int i=0;i<_numBondedPaths;++i) {
-				SharedPtr<Link> link =RR->bc->getLinkBySocket(_policyAlias, _paths[i]->localSocket());
+		for (unsigned int i=0;i<_numBondedPaths;++i) {
 			if (_paths[i] && _paths[i]->allowed()) {
+				SharedPtr<Link> link = RR->bc->getLinkBySocket(_policyAlias, _paths[i]->localSocket());
 				link->setRelativeSpeed(round( ((float)link->speed() / (float)totUserSpecifiedLinkSpeed) * 255));
 			}
 		}
@@ -1376,7 +1375,7 @@ void Bond::processActiveBackupTasks(void *tPtr, const int64_t now)
 						sprintf(traceMsg, "%s (active-backup) Found non-preferred primary link to peer %llx",
 							OSUtils::humanReadableTimestamp().c_str(), _peer->_id.address().toInt());
 						RR->t->bondStateMessage(NULL, traceMsg);
-						_abPath = nonPreferredPath;
+						_abPath = std::move(nonPreferredPath);
 					}
 				}
 				if (!_abPath) {

--- a/node/BondController.cpp
+++ b/node/BondController.cpp
@@ -89,7 +89,6 @@ SharedPtr<Bond> BondController::createTransportTriggeredBond(const RuntimeEnviro
 	Bond *bond = nullptr;
 	char traceMsg[128];
 	if (!_bonds.count(identity)) {
-		std::string policyAlias;
 		if (!_policyTemplateAssignments.count(identity)) {
 			if (_defaultBondingPolicy) {
 				sprintf(traceMsg, "%s (bond) Creating new default %s bond to peer %llx",
@@ -143,6 +142,7 @@ SharedPtr<Bond> BondController::createTransportTriggeredBond(const RuntimeEnviro
 		}
 		return bond;
 	}
+	delete bond;
 	return SharedPtr<Bond>();
 }
 

--- a/node/BondController.hpp
+++ b/node/BondController.hpp
@@ -95,7 +95,7 @@ public:
 	 *
 	 * @param alias Human-readable string alias for bonding policy
 	 */
-	void setBondingLayerDefaultPolicyStr(std::string alias) { _defaultBondingPolicyStr = alias; }
+	void setBondingLayerDefaultPolicyStr(const std::string& alias) { _defaultBondingPolicyStr = std::move(alias); }
 
 	/**
 	 * @return The default bonding policy

--- a/node/CertificateOfMembership.cpp
+++ b/node/CertificateOfMembership.cpp
@@ -113,7 +113,10 @@ void CertificateOfMembership::fromString(const char *s)
 				}
 				bufactual -= 24;
 			}
-		} catch ( ... ) {}
+		} catch ( ... ) {
+			delete [] buf;
+			return;
+		}
 		delete [] buf;
 	}
 

--- a/node/CertificateOfOwnership.hpp
+++ b/node/CertificateOfOwnership.hpp
@@ -60,12 +60,12 @@ public:
 	}
 
 	CertificateOfOwnership(const uint64_t nwid,const int64_t ts,const Address &issuedTo,const uint32_t id)
+		: _issuedTo(issuedTo)
 	{
 		memset(reinterpret_cast<void *>(this),0,sizeof(CertificateOfOwnership));
 		_networkId = nwid;
 		_ts = ts;
 		_id = id;
-		_issuedTo = issuedTo;
 	}
 
 	inline uint64_t networkId() const { return _networkId; }

--- a/node/IncomingPacket.cpp
+++ b/node/IncomingPacket.cpp
@@ -536,8 +536,7 @@ bool IncomingPacket::_doOK(const RuntimeEnvironment *RR,void *tPtr,const SharedP
 		case Packet::VERB_MULTICAST_FRAME: {
 			const unsigned int flags = (*this)[ZT_PROTO_VERB_MULTICAST_FRAME__OK__IDX_FLAGS];
 			networkId = at<uint64_t>(ZT_PROTO_VERB_MULTICAST_FRAME__OK__IDX_NETWORK_ID);
-			const MulticastGroup mg(MAC(field(ZT_PROTO_VERB_MULTICAST_FRAME__OK__IDX_MAC,6),6),at<uint32_t>(ZT_PROTO_VERB_MULTICAST_FRAME__OK__IDX_ADI));
-
+			
 			const SharedPtr<Network> network(RR->node->network(networkId));
 			if (network) {
 				unsigned int offset = 0;
@@ -550,6 +549,8 @@ bool IncomingPacket::_doOK(const RuntimeEnvironment *RR,void *tPtr,const SharedP
 				}
 
 				if ((flags & 0x02) != 0) {
+					const MulticastGroup mg(MAC(field(ZT_PROTO_VERB_MULTICAST_FRAME__OK__IDX_MAC, 6), 6),
+						at<uint32_t>(ZT_PROTO_VERB_MULTICAST_FRAME__OK__IDX_ADI));
 					// OK(MULTICAST_FRAME) includes implicit gather results
 					offset += ZT_PROTO_VERB_MULTICAST_FRAME__OK__IDX_COM_AND_GATHER_RESULTS;
 					unsigned int totalKnown = at<uint32_t>(offset); offset += 4;
@@ -1052,7 +1053,6 @@ bool IncomingPacket::_doMULTICAST_GATHER(const RuntimeEnvironment *RR,void *tPtr
 {
 	const uint64_t nwid = at<uint64_t>(ZT_PROTO_VERB_MULTICAST_GATHER_IDX_NETWORK_ID);
 	const unsigned int flags = (*this)[ZT_PROTO_VERB_MULTICAST_GATHER_IDX_FLAGS];
-	const MulticastGroup mg(MAC(field(ZT_PROTO_VERB_MULTICAST_GATHER_IDX_MAC,6),6),at<uint32_t>(ZT_PROTO_VERB_MULTICAST_GATHER_IDX_ADI));
 	const unsigned int gatherLimit = at<uint32_t>(ZT_PROTO_VERB_MULTICAST_GATHER_IDX_GATHER_LIMIT);
 
 	const SharedPtr<Network> network(RR->node->network(nwid));
@@ -1078,6 +1078,8 @@ bool IncomingPacket::_doMULTICAST_GATHER(const RuntimeEnvironment *RR,void *tPtr
 
 	const int64_t now = RR->node->now();
 	if ((gatherLimit > 0)&&((trustEstablished)||(RR->topology->amUpstream())||(RR->node->localControllerHasAuthorized(now,nwid,peer->address())))) {
+		const MulticastGroup mg(MAC(field(ZT_PROTO_VERB_MULTICAST_GATHER_IDX_MAC, 6), 6),
+			at<uint32_t>(ZT_PROTO_VERB_MULTICAST_GATHER_IDX_ADI));
 		Packet outp(peer->address(),RR->identity.address(),Packet::VERB_OK);
 		outp.append((unsigned char)Packet::VERB_MULTICAST_GATHER);
 		outp.append(packetId());

--- a/node/Membership.cpp
+++ b/node/Membership.cpp
@@ -189,8 +189,7 @@ Membership::AddCredentialResult Membership::addCredential(const RuntimeEnvironme
 				case Credential::CREDENTIAL_TYPE_COO:
 					rt = &(_revocations[credentialKey(ct,rev.credentialId())]);
 					if (*rt < rev.threshold()) {
-						*rt = rev.threshold();
-						_comRevocationThreshold = rev.threshold();
+						*rt = _comRevocationThreshold = rev.threshold();
 						return ADD_ACCEPTED_NEW;
 					}
 					return ADD_ACCEPTED_REDUNDANT;

--- a/node/Multicaster.cpp
+++ b/node/Multicaster.cpp
@@ -361,7 +361,10 @@ void Multicaster::send(
 				}
 			}
 		}
-	} catch ( ... ) {} // this is a sanity check to catch any failures and make sure indexes[] still gets deleted
+	} catch ( ... ) {
+		delete[] indexes;
+		return;
+	} // this is a sanity check to catch any failures and make sure indexes[] still gets deleted
 
 	// Free allocated memory buffer if any
 	if (indexes != idxbuf)

--- a/node/NetworkConfig.cpp
+++ b/node/NetworkConfig.cpp
@@ -29,24 +29,24 @@ bool NetworkConfig::toDictionary(Dictionary<ZT_NETWORKCONFIG_DICT_CAPACITY> &d,b
 
 		// Try to put the more human-readable fields first
 
-		if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_VERSION,(uint64_t)ZT_NETWORKCONFIG_VERSION)) return false;
-		if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_NETWORK_ID,this->networkId)) return false;
-		if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_TIMESTAMP,this->timestamp)) return false;
-		if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_CREDENTIAL_TIME_MAX_DELTA,this->credentialTimeMaxDelta)) return false;
-		if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_REVISION,this->revision)) return false;
-		if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_ISSUED_TO,this->issuedTo.toString(tmp2))) return false;
-		if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_REMOTE_TRACE_TARGET,this->remoteTraceTarget.toString(tmp2))) return false;
-		if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_REMOTE_TRACE_LEVEL,(uint64_t)this->remoteTraceLevel)) return false;
-		if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_FLAGS,this->flags)) return false;
-		if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_MULTICAST_LIMIT,(uint64_t)this->multicastLimit)) return false;
-		if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_TYPE,(uint64_t)this->type)) return false;
-		if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_NAME,this->name)) return false;
-		if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_MTU,(uint64_t)this->mtu)) return false;
+		if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_VERSION,(uint64_t)ZT_NETWORKCONFIG_VERSION)) { delete tmp; return false; }
+		if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_NETWORK_ID,this->networkId)) { delete tmp; return false; }
+		if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_TIMESTAMP,this->timestamp)) { delete tmp; return false; }
+		if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_CREDENTIAL_TIME_MAX_DELTA,this->credentialTimeMaxDelta)) { delete tmp; return false; }
+		if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_REVISION,this->revision)) { delete tmp; return false; }
+		if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_ISSUED_TO,this->issuedTo.toString(tmp2))) { delete tmp; return false; }
+		if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_REMOTE_TRACE_TARGET,this->remoteTraceTarget.toString(tmp2))) { delete tmp; return false; }
+		if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_REMOTE_TRACE_LEVEL,(uint64_t)this->remoteTraceLevel)) { delete tmp; return false; }
+		if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_FLAGS,this->flags)) { delete tmp; return false; }
+		if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_MULTICAST_LIMIT,(uint64_t)this->multicastLimit)) { delete tmp; return false; }
+		if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_TYPE,(uint64_t)this->type)) { delete tmp; return false; }
+		if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_NAME,this->name)) { delete tmp; return false; }
+		if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_MTU,(uint64_t)this->mtu)) { delete tmp; return false; }
 
 #ifdef ZT_SUPPORT_OLD_STYLE_NETCONF
 		if (includeLegacy) {
-			if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_ENABLE_BROADCAST_OLD,this->enableBroadcast())) return false;
-			if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_PRIVATE_OLD,this->isPrivate())) return false;
+			if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_ENABLE_BROADCAST_OLD,this->enableBroadcast())) { delete tmp; return false; }
+			if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_PRIVATE_OLD,this->isPrivate())) { delete tmp; return false; }
 
 			std::string v4s;
 			for(unsigned int i=0;i<staticIpCount;++i) {
@@ -58,7 +58,7 @@ bool NetworkConfig::toDictionary(Dictionary<ZT_NETWORKCONFIG_DICT_CAPACITY> &d,b
 				}
 			}
 			if (v4s.length() > 0) {
-				if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_IPV4_STATIC_OLD,v4s.c_str())) return false;
+				if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_IPV4_STATIC_OLD,v4s.c_str())) { delete tmp; return false; }
 			}
 			std::string v6s;
 			for(unsigned int i=0;i<staticIpCount;++i) {
@@ -70,7 +70,7 @@ bool NetworkConfig::toDictionary(Dictionary<ZT_NETWORKCONFIG_DICT_CAPACITY> &d,b
 				}
 			}
 			if (v6s.length() > 0) {
-				if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_IPV6_STATIC_OLD,v6s.c_str())) return false;
+				if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_IPV6_STATIC_OLD,v6s.c_str())) { delete tmp; return false; }
 			}
 
 			std::string ets;
@@ -92,11 +92,11 @@ bool NetworkConfig::toDictionary(Dictionary<ZT_NETWORKCONFIG_DICT_CAPACITY> &d,b
 				lastrt = rt;
 			}
 			if (ets.length() > 0) {
-				if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_ALLOWED_ETHERNET_TYPES_OLD,ets.c_str())) return false;
+				if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_ALLOWED_ETHERNET_TYPES_OLD,ets.c_str())) { delete tmp; return false; }
 			}
 
 			if (this->com) {
-				if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_CERTIFICATE_OF_MEMBERSHIP_OLD,this->com.toString().c_str())) return false;
+				if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_CERTIFICATE_OF_MEMBERSHIP_OLD,this->com.toString().c_str())) { delete tmp; return false; }
 			}
 
 			std::string ab;
@@ -109,7 +109,7 @@ bool NetworkConfig::toDictionary(Dictionary<ZT_NETWORKCONFIG_DICT_CAPACITY> &d,b
 				}
 			}
 			if (ab.length() > 0) {
-				if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_ACTIVE_BRIDGES_OLD,ab.c_str())) return false;
+				if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_ACTIVE_BRIDGES_OLD,ab.c_str())) { delete tmp; return false; }
 			}
 		}
 #endif // ZT_SUPPORT_OLD_STYLE_NETCONF
@@ -119,35 +119,35 @@ bool NetworkConfig::toDictionary(Dictionary<ZT_NETWORKCONFIG_DICT_CAPACITY> &d,b
 		if (this->com) {
 			tmp->clear();
 			this->com.serialize(*tmp);
-			if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_COM,*tmp)) return false;
+			if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_COM,*tmp)) { delete tmp; return false; }
 		}
 
 		tmp->clear();
 		for(unsigned int i=0;i<this->capabilityCount;++i)
 			this->capabilities[i].serialize(*tmp);
 		if (tmp->size()) {
-			if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_CAPABILITIES,*tmp)) return false;
+			if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_CAPABILITIES,*tmp)) { delete tmp; return false; }
 		}
 
 		tmp->clear();
 		for(unsigned int i=0;i<this->tagCount;++i)
 			this->tags[i].serialize(*tmp);
 		if (tmp->size()) {
-			if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_TAGS,*tmp)) return false;
+			if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_TAGS,*tmp)) { delete tmp; return false; }
 		}
 
 		tmp->clear();
 		for(unsigned int i=0;i<this->certificateOfOwnershipCount;++i)
 			this->certificatesOfOwnership[i].serialize(*tmp);
 		if (tmp->size()) {
-			if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_CERTIFICATES_OF_OWNERSHIP,*tmp)) return false;
+			if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_CERTIFICATES_OF_OWNERSHIP,*tmp)) { delete tmp; return false; }
 		}
 
 		tmp->clear();
 		for(unsigned int i=0;i<this->specialistCount;++i)
 			tmp->append((uint64_t)this->specialists[i]);
 		if (tmp->size()) {
-			if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_SPECIALISTS,*tmp)) return false;
+			if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_SPECIALISTS,*tmp)) { delete tmp; return false; }
 		}
 
 		tmp->clear();
@@ -158,28 +158,28 @@ bool NetworkConfig::toDictionary(Dictionary<ZT_NETWORKCONFIG_DICT_CAPACITY> &d,b
 			tmp->append((uint16_t)this->routes[i].metric);
 		}
 		if (tmp->size()) {
-			if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_ROUTES,*tmp)) return false;
+			if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_ROUTES,*tmp)) { delete tmp; return false; }
 		}
 
 		tmp->clear();
 		for(unsigned int i=0;i<this->staticIpCount;++i)
 			this->staticIps[i].serialize(*tmp);
 		if (tmp->size()) {
-			if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_STATIC_IPS,*tmp)) return false;
+			if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_STATIC_IPS,*tmp)) { delete tmp; return false; }
 		}
 
 		if (this->ruleCount) {
 			tmp->clear();
 			Capability::serializeRules(*tmp,rules,ruleCount);
 			if (tmp->size()) {
-				if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_RULES,*tmp)) return false;
+				if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_RULES,*tmp)) { delete tmp; return false; }
 			}
 		}
 
 		tmp->clear();
 		DNS::serializeDNS(*tmp, &dns);
 		if (tmp->size()) {
-			if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_DNS,*tmp)) return false;
+			if (!d.add(ZT_NETWORKCONFIG_DICT_KEY_DNS,*tmp)) { delete tmp; return false; }
 		}
 
 		delete tmp;
@@ -300,7 +300,10 @@ bool NetworkConfig::fromDictionary(const Dictionary<ZT_NETWORKCONFIG_DICT_CAPACI
 						p += cap.deserialize(*tmp,p);
 						this->capabilities[this->capabilityCount++] = cap;
 					}
-				} catch ( ... ) {}
+				} catch ( ... ) {
+					delete tmp;
+					return false;
+				}
 				std::sort(&(this->capabilities[0]),&(this->capabilities[this->capabilityCount]));
 			}
 
@@ -312,7 +315,10 @@ bool NetworkConfig::fromDictionary(const Dictionary<ZT_NETWORKCONFIG_DICT_CAPACI
 						p += tag.deserialize(*tmp,p);
 						this->tags[this->tagCount++] = tag;
 					}
-				} catch ( ... ) {}
+				} catch ( ... ) {
+					delete tmp;
+					return false;
+				}
 				std::sort(&(this->tags[0]),&(this->tags[this->tagCount]));
 			}
 

--- a/node/Peer.cpp
+++ b/node/Peer.cpp
@@ -561,7 +561,7 @@ void Peer::clusterRedirect(void *tPtr,const SharedPtr<Path> &originatingPath,con
 		}
 		if (j < ZT_MAX_PEER_NETWORK_PATHS) {
 			_paths[j].lr = now;
-			_paths[j].p = np;
+			_paths[j].p = std::move(np);
 			_paths[j].priority = newPriority;
 			++j;
 			while (j < ZT_MAX_PEER_NETWORK_PATHS) {

--- a/node/Switch.cpp
+++ b/node/Switch.cpp
@@ -642,6 +642,7 @@ void Switch::aqm_enqueue(void *tPtr, const SharedPtr<Network> &network, Packet &
 		}
 	}
 	if (!selectedQueue) {
+		_aqm_m.unlock();
 		return;
 	}
 
@@ -831,7 +832,7 @@ void Switch::aqm_dequeue(void *tPtr)
 				break;
 			}
 		}
-		nqcb++;
+		++nqcb;
 		_aqm_m.unlock();
 	}
 }


### PR DESCRIPTION
By default, windows.h defines `min` and `max` as macros. When those are expanded, code that tries to use `std::min` (for example) will end up looking something like this:

```cpp
int k = std::(x) < (y) ? (x) : (y);
```

The error message is telling you that `std::(x)` isn't allowed.