### PR TITLE
Multiple image fixes:

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -15,8 +15,10 @@ COPY --from=stage zerotier-one.deb .
 
 RUN dpkg -i zerotier-one.deb && rm -f zerotier-one.deb
 RUN echo "${VERSION}" >/etc/zerotier-version
+RUN rm -rf /var/lib/zerotier-one
 
 COPY entrypoint.sh.release /entrypoint.sh
 RUN chmod 755 /entrypoint.sh
 
-CMD /entrypoint.sh
+CMD []
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh.release
+++ b/entrypoint.sh.release
@@ -5,6 +5,31 @@ grepzt() {
   return $?
 }
 
+mkztfile() {
+  file=$1
+  mode=$2
+  content=$3
+
+  mkdir -p /var/lib/zerotier-one
+  echo "$content" > "/var/lib/zerotier-one/$file"
+  chmod "$mode" "/var/lib/zerotier-one/$file"
+}
+
+if [ "x$ZEROTIER_API_SECRET" != "x" ]
+then
+  mkztfile authtoken.secret 0600 "$ZEROTIER_API_SECRET"
+fi
+
+if [ "x$ZEROTIER_IDENTITY_PUBLIC" != "x" ]
+then
+  mkztfile identity.public 0644 "$ZEROTIER_IDENTITY_PUBLIC"
+fi
+
+if [ "x$ZEROTIER_IDENTITY_SECRET" != "x" ]
+then
+  mkztfile identity.secret 0600 "$ZEROTIER_IDENTITY_SECRET"
+fi
+
 echo "starting zerotier"
 setsid /usr/sbin/zerotier-one &
 
@@ -14,7 +39,7 @@ do
   sleep 1
 done
 
-echo "joining networks"
+echo "joining networks: $@"
 
 for i in "$@"
 do


### PR DESCRIPTION
- Can now provide the following environment variables to populate
secrets (nice for kubernetes, other situations)
  - ZEROTIER_API_SECRET: authtoken.secret
  - ZEROTIER_IDENTITY_PUBLIC: identity.public
  - ZEROTIER_IDENTITY_SECRET: identity.secret
- Joining networks by providing them as a part of docker's "command"
array should now work properly

Signed-off-by: Erik Hollensbe <linux@hollensbe.org>