### PR TITLE
Set MAC address before bringing up Linux TAP link

### DIFF
--- a/osdep/LinuxEthernetTap.cpp
+++ b/osdep/LinuxEthernetTap.cpp
@@ -207,6 +207,15 @@ LinuxEthernetTap::LinuxEthernetTap(
 					printf("WARNING: ioctl() failed setting up Linux tap device (bring interface up)\n");
 					return;
 				}
+
+				ifr.ifr_ifru.ifru_hwaddr.sa_family = ARPHRD_ETHER;
+				_mac.copyTo(ifr.ifr_ifru.ifru_hwaddr.sa_data,6);
+				if (ioctl(sock,SIOCSIFHWADDR,(void *)&ifr) < 0) {
+					::close(sock);
+					printf("WARNING: ioctl() failed setting up Linux tap device (set MAC)\n");
+					return;
+				}
+
 				ifr.ifr_flags |= IFF_UP;
 				if (ioctl(sock,SIOCSIFFLAGS,(void *)&ifr) < 0) {
 					::close(sock);
@@ -219,14 +228,6 @@ LinuxEthernetTap::LinuxEthernetTap(
 				// harmless. This was moved to the worker thread though so as not to block the
 				// main ZeroTier loop.
 				usleep(500000);
-
-				ifr.ifr_ifru.ifru_hwaddr.sa_family = ARPHRD_ETHER;
-				_mac.copyTo(ifr.ifr_ifru.ifru_hwaddr.sa_data,6);
-				if (ioctl(sock,SIOCSIFHWADDR,(void *)&ifr) < 0) {
-					::close(sock);
-					printf("WARNING: ioctl() failed setting up Linux tap device (set MAC)\n");
-					return;
-				}
 
 				ifr.ifr_ifru.ifru_mtu = (int)_mtu;
 				if (ioctl(sock,SIOCSIFMTU,(void *)&ifr) < 0) {

--- a/osdep/LinuxEthernetTap.cpp
+++ b/osdep/LinuxEthernetTap.cpp
@@ -207,6 +207,12 @@ LinuxEthernetTap::LinuxEthernetTap(
 					printf("WARNING: ioctl() failed setting up Linux tap device (bring interface up)\n");
 					return;
 				}
+				ifr.ifr_flags |= IFF_UP;
+				if (ioctl(sock,SIOCSIFFLAGS,(void *)&ifr) < 0) {
+					::close(sock);
+					printf("WARNING: ioctl() failed setting up Linux tap device (bring interface up)\n");
+					return;
+				}
 
 				// Some kernel versions seem to require you to yield while the device comes up
 				// before they will accept MTU and MAC. For others it doesn't matter, but is
@@ -226,13 +232,6 @@ LinuxEthernetTap::LinuxEthernetTap(
 				if (ioctl(sock,SIOCSIFMTU,(void *)&ifr) < 0) {
 					::close(sock);
 					printf("WARNING: ioctl() failed setting up Linux tap device (set MTU)\n");
-					return;
-				}
-
-				ifr.ifr_flags |= IFF_UP;
-				if (ioctl(sock,SIOCSIFFLAGS,(void *)&ifr) < 0) {
-					::close(sock);
-					printf("WARNING: ioctl() failed setting up Linux tap device (bring interface up)\n");
 					return;
 				}
 


### PR DESCRIPTION
This corrects the flow for bringing up a TAP device under Linux by setting the device MAC address prior to bringing up the device.

This also fixes an issue with ZT running on guests under OpenVZ 6 caused by https://github.com/zerotier/ZeroTierOne/commit/d735a1d04cf1d8236d531210e7361607d2774a13 (determined by a `git bisect` between 1.4.6 and 1.6.5).