### PR TITLE
Fix erroneous cast of verb to double that causes invalid tracing output

### DIFF
--- a/node/Trace.cpp
+++ b/node/Trace.cpp
@@ -69,7 +69,7 @@ void Trace::peerConfirmingUnknownPath(void *const tPtr,const uint64_t networkId,
 	char tmp[128];
 	if (!path) return; // sanity check
 
-	ZT_LOCAL_TRACE(tPtr,RR,"trying unknown path %s to %.10llx (packet %.16llx verb %d local socket %lld network %.16llx)",path->address().toString(tmp),peer.address().toInt(),packetId,(double)verb,path->localSocket(),networkId);
+	ZT_LOCAL_TRACE(tPtr,RR,"trying unknown path %s to %.10llx (packet %.16llx verb %d local socket %lld network %.16llx)",path->address().toString(tmp),peer.address().toInt(),packetId,verb,path->localSocket(),networkId);
 
 	std::pair<Address,Trace::Level> byn;
 	if (networkId) { Mutex::Lock l(_byNet_m); _byNet.get(networkId,byn); }


### PR DESCRIPTION
Casting verb to double could cause trace outputs to read from incorrect memory locations. For example:

`trying unknown path fd00::3ab/35991 to c7467550ad (packet 62be217379be6ea2 verb 9440 local socket 0 network 00007ffd3c53cea0)`