### PR TITLE
Use clang on OpenBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ ifeq ($(OSTYPE),FreeBSD)
 	include make-bsd.mk
 endif
 ifeq ($(OSTYPE),OpenBSD)
-	CC=egcc
-	CXX=eg++
+	CC=clang
+	CXX=clang++
 	ZT_BUILD_PLATFORM=9
 	include make-bsd.mk
 endif


### PR DESCRIPTION
OpenBSD has been using clang as the default compiler for i386 & amd64 platforms since mid-2017. Making this change is all that's needed to compile and run master on the latest stable release (6.9) - I'm able to join networks, log in over SSH, etc.

In addition, there's a simple rc.d(8) script to control the ZeroTierOne daemon as a system service:

```shell
#!/bin/ksh
daemon="/usr/local/sbin/zerotier-one -d"
. /etc/rc.d/rc.subr
rc_cmd $1
```

It can be installed with `install -m 555 -o root -g wheel ./zerotier-rc-d /etc/rc.d/zerotier` - I'd include it in the PR but I'm not sure what would be the best place to put it in the source tree.