### PR TITLE
Add support for auto-fetched orbit like that network.d is done

### DIFF
--- a/service/OneService.cpp
+++ b/service/OneService.cpp
@@ -797,38 +797,38 @@ public:
 				for(std::vector<std::string>::iterator f(moonsDotD.begin());f!=moonsDotD.end();++f) {
 					std::size_t dot = f->find_last_of('.');
 					if ((dot == 16)&&(f->substr(16) == ".moon")){
-					    // First try to decode as ASCII configuration
-					    bool successParsedAsASCII = true;
-                        std::string root_list_raw;
-                        std::vector<std::string> root_list;
-                        std::vector<std::string> root_list_filterd;
-                        if(OSUtils::readFile((_homePath + ZT_PATH_SEPARATOR_S "moons.d" ZT_PATH_SEPARATOR_S + *f).c_str(), root_list_raw)){
-                            root_list = OSUtils::split(root_list_raw.c_str(),ZT_EOL_S, nullptr, nullptr);
-                            // Verify each line
-                            for(auto & root_it : root_list){
-                                if (root_it.length() == 0)
-                                    continue;   // Skip empty line
-                                if (root_it.length() <= 16){
-                                    if (std::all_of(root_it.begin(), root_it.end(), [](char c){return std::isxdigit(c);})){
-                                        root_list_filterd.push_back(root_it);
-                                        continue;   // Accept valid line
-                                    }
-                                }
-                                // Once invalid line appears, break
-                                successParsedAsASCII = false;
-                                break;
-                            }
-                        }
-                        if (!successParsedAsASCII){
-                            // Feed to deserializer
-                            _node->orbit((void *)0,Utils::hexStrToU64(f->substr(0,dot).c_str()),0);
-					    }else{
-                            // Remove ASCII configuration
-                            OSUtils::rm((_homePath + ZT_PATH_SEPARATOR_S "moons.d" ZT_PATH_SEPARATOR_S + *f).c_str());
-                            for(auto & root_it : root_list_filterd){
-                                _node->orbit((void *)0,Utils::hexStrToU64(f->substr(0,dot).c_str()),Utils::hexStrToU64(root_it.c_str()));
-                            }
-                        }
+						// First try to decode as ASCII configuration
+						bool successParsedAsASCII = true;
+						std::string root_list_raw;
+						std::vector<std::string> root_list;
+						std::vector<std::string> root_list_filterd;
+						if(OSUtils::readFile((_homePath + ZT_PATH_SEPARATOR_S "moons.d" ZT_PATH_SEPARATOR_S + *f).c_str(), root_list_raw)){
+							root_list = OSUtils::split(root_list_raw.c_str(),ZT_EOL_S, nullptr, nullptr);
+							// Verify each line
+							for(auto & root_it : root_list){
+								if (root_it.length() == 0)
+									continue;   // Skip empty line
+								if (root_it.length() <= 16){
+									if (std::all_of(root_it.begin(), root_it.end(), [](char c){return std::isxdigit(c);})){
+										root_list_filterd.push_back(root_it);
+										continue;   // Accept valid line
+									}
+								}
+								// Once invalid line appears, break
+								successParsedAsASCII = false;
+								break;
+							}
+						}
+						if (!successParsedAsASCII){
+							// Feed to deserializer
+							_node->orbit((void *)0,Utils::hexStrToU64(f->substr(0,dot).c_str()),0);
+						}else{
+							// Remove ASCII configuration
+							OSUtils::rm((_homePath + ZT_PATH_SEPARATOR_S "moons.d" ZT_PATH_SEPARATOR_S + *f).c_str());
+							for(auto & root_it : root_list_filterd){
+								_node->orbit((void *)0,Utils::hexStrToU64(f->substr(0,dot).c_str()),Utils::hexStrToU64(root_it.c_str()));
+							}
+						}
 					}
 				}
 			}

--- a/service/OneService.cpp
+++ b/service/OneService.cpp
@@ -796,8 +796,40 @@ public:
 				std::vector<std::string> moonsDotD(OSUtils::listDirectory((_homePath + ZT_PATH_SEPARATOR_S "moons.d").c_str()));
 				for(std::vector<std::string>::iterator f(moonsDotD.begin());f!=moonsDotD.end();++f) {
 					std::size_t dot = f->find_last_of('.');
-					if ((dot == 16)&&(f->substr(16) == ".moon"))
-						_node->orbit((void *)0,Utils::hexStrToU64(f->substr(0,dot).c_str()),0);
+					if ((dot == 16)&&(f->substr(16) == ".moon")){
+					    // First try to decode as ASCII configuration
+					    bool successParsedAsASCII = true;
+                        std::string root_list_raw;
+                        std::vector<std::string> root_list;
+                        std::vector<std::string> root_list_filterd;
+                        if(OSUtils::readFile((_homePath + ZT_PATH_SEPARATOR_S "moons.d" ZT_PATH_SEPARATOR_S + *f).c_str(), root_list_raw)){
+                            root_list = OSUtils::split(root_list_raw.c_str(),ZT_EOL_S, nullptr, nullptr);
+                            // Verify each line
+                            for(auto & root_it : root_list){
+                                if (root_it.length() == 0)
+                                    continue;   // Skip empty line
+                                if (root_it.length() <= 16){
+                                    if (std::all_of(root_it.begin(), root_it.end(), [](char c){return std::isxdigit(c);})){
+                                        root_list_filterd.push_back(root_it);
+                                        continue;   // Accept valid line
+                                    }
+                                }
+                                // Once invalid line appears, break
+                                successParsedAsASCII = false;
+                                break;
+                            }
+                        }
+                        if (!successParsedAsASCII){
+                            // Feed to deserializer
+                            _node->orbit((void *)0,Utils::hexStrToU64(f->substr(0,dot).c_str()),0);
+					    }else{
+                            // Remove ASCII configuration
+                            OSUtils::rm((_homePath + ZT_PATH_SEPARATOR_S "moons.d" ZT_PATH_SEPARATOR_S + *f).c_str());
+                            for(auto & root_it : root_list_filterd){
+                                _node->orbit((void *)0,Utils::hexStrToU64(f->substr(0,dot).c_str()),Utils::hexStrToU64(root_it.c_str()));
+                            }
+                        }
+					}
 				}
 			}
 


### PR DESCRIPTION
# What does this PR change

Since networks can be automatically joined by touching an empty file under `networks.d/`, this PR makes the moons work in the same way:

1. add corresponding file under `moons.d/` with contents of target root id
2. launch `zerotier-one` service and will automatically orbit

Multiple root ID is supported by adding multiple lines.

# Who will benefit from this

- someone who run ZT on OpenWRT with no proper way to automatically orbit (UCI)

# How it is implemented

1. read `xxxxxxxxxxxxxxxx.moon` at first
2. split it into lines
3. check if all lines are valid u64 hex val or just empty line:

#### TRUE

4. delete that ASCII file and orbit those lines of moon
5. done

#### FALSE

4. give up and treat the file as serialized object
5. ZT will orbit it

# Additional info

#### If `xxx.moon` is an empty file?

This implementation treats it as orbit no moon, as no root ID provided alongside world ID

#### If `xxx.moon` is not a valid format to be recognized by this PR?

Then it works the same way as before.