### PR TITLE
cleaning up docker entryoint logic and disusing nohup

### DIFF
--- a/entrypoint.sh.release
+++ b/entrypoint.sh.release
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 grepzt() {
-  [ ! -n "$(cat /var/lib/zerotier-one/zerotier-one.pid)" -a -d "/proc/$(cat /var/lib/zerotier-one/zerotier-one.pid)" ]
+  [ -n "$(cat /var/lib/zerotier-one/zerotier-one.pid)" ] && [ -d "/proc/$(cat /var/lib/zerotier-one/zerotier-one.pid)" ]
   return $?
 }
 
@@ -34,14 +34,14 @@ mkztfile zerotier-one.port 0600 "9993"
 
 killzerotier() {
   echo "Killing zerotier"
-  kill $(cat /var/lib/zerotier-one/zerotier-one.pid)  
+  kill $(cat /var/lib/zerotier-one/zerotier-one.pid)
   exit 0
 }
 
 trap killzerotier INT TERM
 
 echo "starting zerotier"
-nohup /usr/sbin/zerotier-one &
+/usr/sbin/zerotier-one -d < /dev/null 2>&1
 
 while ! grepzt
 do
@@ -56,7 +56,7 @@ do
   echo "joining $i"
 
   while ! zerotier-cli join "$i"
-  do 
+  do
     echo "joining $i failed; trying again in 1s"
     sleep 1
   done


### PR DESCRIPTION
Test logic -
-a and -o have been marked obsolescent - https://pubs.opengroup.org/onlinepubs/9699919799/utilities/test.html

nohup:
ZeroTier -d forks.. this will allow debug and trace info to show up in docker logs
https://github.com/zerotier/ZeroTierOne/blob/6faca86bb424d0b9643b6efa50571f73310d8276/one.cpp#L2259

