### PR TITLE
add null check

### DIFF
--- a/windows/WinUI/NetworkMonitor.cs
+++ b/windows/WinUI/NetworkMonitor.cs
@@ -102,10 +102,10 @@ namespace WinUI
 
         private void apiNetworkCallback(List<ZeroTierNetwork> networks)
         {
-						if (networks == null)
-						{
-								return;
-						}
+            if (networks == null)
+            {
+                return;
+            }
 
             lock (_knownNetworks)
             {
@@ -132,7 +132,10 @@ namespace WinUI
 
         private void apiStatusCallback(ZeroTierStatus status)
         {
-            _stCb(status);
+            if (_stCb != null)
+            {
+                _stCb(status);
+            }
         }
 
         private void run()


### PR DESCRIPTION
## Summary

On my Windows system, the tray app more than often shows "Node ID: unknown". This PR completely fixes this issue for me.

## Explanation

I did some digging and found that a missing null check is causing the monitor update thread to die silently.
At least on my system, the `apiStatusCallback` gets fired **before** `SubscribeStatusUpdates`. With the null check added, the thread doesn't die and this issue is fixed.

## Issue screenshot (before fix)

![image](https://user-images.githubusercontent.com/5162718/123765516-272b1500-d909-11eb-9fad-d800b3ffe390.png)

After applying the PR, the Node ID and the networks list all works as expected :)