### PR TITLE
Don't use v6 source addresses for v4 routes

### DIFF
--- a/service/OneService.cpp
+++ b/service/OneService.cpp
@@ -2047,7 +2047,7 @@ public:
 				unsigned int mostMatchingPrefixBits = 0;
 				for(std::set<InetAddress>::const_iterator i(myIps.begin());i!=myIps.end();++i) {
 					const unsigned int matchingPrefixBits = i->matchingPrefixBits(*target);
-					if (matchingPrefixBits >= mostMatchingPrefixBits) {
+					if (matchingPrefixBits >= mostMatchingPrefixBits && ((target->isV4() && i->isV4()) || (target->isV6() && i->isV6()))) {
 						mostMatchingPrefixBits = matchingPrefixBits;
 						src = &(*i);
 					}


### PR DESCRIPTION
Don't use v6 source addresses for v4 routes

and vice versa.

For issue #1104

With some printf debugging, I was seeing:

```
here, src fe80::3c7a:2dff:fe0c:21ed, target 10.147.20.0, matchingPrefixBits 0, mostMatchingPrefixBits 0
here, src fd8b:d512:4fd6:255:3c99:932f:2fda:6eff, target 10.147.20.0, matchingPrefixBits 0, mostMatchingPrefixBits 0
```

which means (matchingPrefixBits >= mostMatchingPrefixBits) would be true

Then somewhere downstream from there on mac (and probably BSD), the default route would
get messed up:

`default via 92:29:f1:6f:2f:76 dev en0`

Tested on mac and linux so far.