### PR TITLE
Update PGP keyserver URL

### DIFF
--- a/ext/installfiles/linux/zerotier-containerized/Dockerfile
+++ b/ext/installfiles/linux/zerotier-containerized/Dockerfile
@@ -5,7 +5,7 @@ FROM debian:buster-slim as builder
 ## Supports x86_64, x86, arm, and arm64
 
 RUN apt-get update && apt-get install -y curl gnupg
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 0x1657198823e52a61  && \
+RUN apt-key adv --keyserver pgp.mit.edu --recv-keys 0x1657198823e52a61  && \
     echo "deb http://download.zerotier.com/debian/buster buster main" > /etc/apt/sources.list.d/zerotier.list
 RUN apt-get update && apt-get install -y zerotier-one=1.6.2
 COPY ext/installfiles/linux/zerotier-containerized/main.sh /var/lib/zerotier-one/main.sh


### PR DESCRIPTION
Closes #1450

I replaced the old keyserver URL with a new one. The image build completes successfully with this change.