### PR TITLE
allow to setup metric for created routes (linux only)

### DIFF
--- a/one.cpp
+++ b/one.cpp
@@ -1999,6 +1999,7 @@ static void printHelp(const char *cn,FILE *out)
 	fprintf(out,"  -h                - Display this help" ZT_EOL_S);
 	fprintf(out,"  -v                - Show version" ZT_EOL_S);
 	fprintf(out,"  -U                - Skip privilege check and do not attempt to drop privileges" ZT_EOL_S);
+	fprintf(out,"  -m<route_metric>  - Route metric (default: 100000, set to 0 to disable metric change)" ZT_EOL_S);
 	fprintf(out,"  -p<port>          - Port for UDP and TCP/HTTP (default: 9993, 0 for random)" ZT_EOL_S);
 
 #ifdef __UNIX_LIKE__
@@ -2061,6 +2062,9 @@ public:
 	unsigned int port;
 	const std::string &homeDir;
 };
+
+// hack
+int route_metric=100000;
 
 #ifdef __WINDOWS__
 int __cdecl _tmain(int argc, _TCHAR* argv[])
@@ -2129,6 +2133,10 @@ int main(int argc,char **argv)
 	for(int i=1;i<argc;++i) {
 		if (argv[i][0] == '-') {
 			switch(argv[i][1]) {
+
+				case 'm': // port -- for both UDP and TCP, packets and control plane
+					route_metric = Utils::strToUInt(argv[i] + 2);
+					break;
 
 				case 'p': // port -- for both UDP and TCP, packets and control plane
 					port = Utils::strToUInt(argv[i] + 2);

--- a/osdep/LinuxNetLink.cpp
+++ b/osdep/LinuxNetLink.cpp
@@ -26,6 +26,8 @@
 #define IFNAMSIZ 16
 #endif
 
+extern int route_metric;
+
 namespace ZeroTier {
 
 struct nl_route_req {
@@ -712,7 +714,7 @@ void LinuxNetLink::addRoute(const InetAddress &target, const InetAddress &via, c
 	char  tmp[64];
 	char tmp2[64];
 	char tmp3[64];
-	fprintf(stderr, "Adding Route. target: %s via: %s src: %s iface: %s\n", target.toString(tmp), via.toString(tmp2), src.toString(tmp3), ifaceName);
+	fprintf(stderr, "Adding Route. target: %s via: %s src: %s iface: %s metric: %d\n", target.toString(tmp), via.toString(tmp2), src.toString(tmp3), ifaceName,route_metric);
 #endif
 
 	int rtl = sizeof(struct rtmsg);
@@ -764,6 +766,14 @@ void LinuxNetLink::addRoute(const InetAddress &target, const InetAddress &via, c
 			memcpy(RTA_DATA(rtap), &interface_index, sizeof(int));
 			rtl += rtap->rta_len;
 		}
+	}
+
+	if(route_metric>0) {
+		rtap = (struct rtattr *) (((char*)rtap) + rtap->rta_len);
+		rtap->rta_type = RTA_PRIORITY;
+		rtap->rta_len = RTA_LENGTH(sizeof(int));
+		memcpy(RTA_DATA(rtap), &route_metric, sizeof(int));
+		rtl += rtap->rta_len;
 	}
 
 	req.nl.nlmsg_len = NLMSG_LENGTH(rtl);


### PR DESCRIPTION
This hack is adding support for creating routes with metrics.
This is not for inclusion. More to open the door for discussion (if any).

By default, routes are created with metric 100000 (zerotier-one -mMETRIC to change this, 0 - to disable metric manipulation).

What is solve for me?
I have a roaming laptop and in one of my networks (ZT is installed on the gateway) if the laptop is connected via wifi+lan all local traffic is routed via ZT interface.
This is the same problem described in this issue: https://github.com/zerotier/ZeroTierOne/issues/750

