### PR TITLE
Bump ZeroTier version for containerized builds to 1.6.6, update keyserver

### DIFF
--- a/ext/installfiles/linux/zerotier-containerized/Dockerfile
+++ b/ext/installfiles/linux/zerotier-containerized/Dockerfile
@@ -5,13 +5,13 @@ FROM debian:buster-slim as builder
 ## Supports x86_64, x86, arm, and arm64
 
 RUN apt-get update && apt-get install -y curl gnupg
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 0x1657198823e52a61  && \
+RUN apt-key adv --keyserver keys.openpgp.org --recv-keys 0x1657198823e52a61  && \
     echo "deb http://download.zerotier.com/debian/buster buster main" > /etc/apt/sources.list.d/zerotier.list
-RUN apt-get update && apt-get install -y zerotier-one=1.6.2
+RUN apt-get update && apt-get install -y zerotier-one=1.6.6
 COPY ext/installfiles/linux/zerotier-containerized/main.sh /var/lib/zerotier-one/main.sh
 
 FROM debian:buster-slim
-LABEL version="1.6.3"
+LABEL version="1.6.6"
 LABEL description="Containerized ZeroTier One for use on CoreOS or other Docker-only Linux hosts."
 
 # ZeroTier relies on UDP port 9993


### PR DESCRIPTION
Bump of the ZeroTier version used in the docker container after the [recent security fix](https://www.zerotier.com/2021/09/21/incident-response-to-september-20th-2021/) to [1.6.6](https://github.com/zerotier/ZeroTierOne/blob/master/RELEASE-NOTES.md#2021-09-21----version-166). 

I could not find a default version in the [Dockerfile.release](https://github.com/zerotier/ZeroTierOne/blob/dev/Dockerfile.release), since `VERSION` is required, I assume the [zerotier/zerotier](https://hub.docker.com/r/zerotier/zerotier) image is built & pushed by the ZT team itself.

FYI, I am aware of https://github.com/zerotier/ZeroTierOne/pull/1451 for https://github.com/zerotier/ZeroTierOne/issues/1450 but with that keyserver the build was stuck on 
```
Executing: /tmp/apt-key-gpghome.0Bz4lJmXGr/gpg.1.sh --keyserver pgp.mit.edu --recv-keys 0x1657198823e52a61
```
that's why i moved it to the openpgp keyserver which runs through smoothly:
```
Executing: /tmp/apt-key-gpghome.3znQPmBekh/gpg.1.sh --keyserver keys.openpgp.org --recv-keys 0x1657198823e52a61
gpg: key 1657198823E52A61: public key "ZeroTier, Inc. (ZeroTier Support and Release Signing Key) <contact@zerotier.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1

```