### PR TITLE
Add functionality to enable or disable networks (fixes #659)

### DIFF
--- a/include/ZeroTierOne.h
+++ b/include/ZeroTierOne.h
@@ -674,7 +674,12 @@ enum ZT_VirtualNetworkStatus
 	/**
 	 * External authentication is required (e.g. SSO)
 	 */
-	ZT_NETWORK_STATUS_AUTHENTICATION_REQUIRED = 6
+	ZT_NETWORK_STATUS_AUTHENTICATION_REQUIRED = 6,
+
+	/**
+	 * The network is disabled by local config setting
+	 */
+	ZT_NETWORK_DISABLED = 7
 };
 
 /**

--- a/node/Network.cpp
+++ b/node/Network.cpp
@@ -589,6 +589,9 @@ Network::Network(const RuntimeEnvironment *renv,void *tPtr,uint64_t nwid,void *u
 		memset(&ctmp, 0, sizeof(ZT_VirtualNetworkConfig));
 		_externalConfig(&ctmp);
 		_portError = RR->node->configureVirtualNetworkPort(tPtr,_id,&_uPtr,ZT_VIRTUAL_NETWORK_CONFIG_OPERATION_UP,&ctmp);
+		if (_portError == -1001) {
+			destroy();
+		}
 		_portInitialized = true;
 	}
 }
@@ -1380,6 +1383,8 @@ ZT_VirtualNetworkStatus Network::_status() const
 {
 	// assumes _lock is locked
 	if (_portError)
+		if (_portError == -1001)
+			return ZT_NETWORK_DISABLED;
 		return ZT_NETWORK_STATUS_PORT_ERROR;
 	switch(_netconfFailure) {
 		case NETCONF_FAILURE_ACCESS_DENIED:

--- a/node/Network.cpp
+++ b/node/Network.cpp
@@ -589,9 +589,6 @@ Network::Network(const RuntimeEnvironment *renv,void *tPtr,uint64_t nwid,void *u
 		memset(&ctmp, 0, sizeof(ZT_VirtualNetworkConfig));
 		_externalConfig(&ctmp);
 		_portError = RR->node->configureVirtualNetworkPort(tPtr,_id,&_uPtr,ZT_VIRTUAL_NETWORK_CONFIG_OPERATION_UP,&ctmp);
-		if (_portError == -1001) {
-			destroy();
-		}
 		_portInitialized = true;
 	}
 }
@@ -1382,10 +1379,11 @@ void Network::destroy()
 ZT_VirtualNetworkStatus Network::_status() const
 {
 	// assumes _lock is locked
-	if (_portError)
+	if (_portError) {
 		if (_portError == -1001)
 			return ZT_NETWORK_DISABLED;
 		return ZT_NETWORK_STATUS_PORT_ERROR;
+	}
 	switch(_netconfFailure) {
 		case NETCONF_FAILURE_ACCESS_DENIED:
 			return ZT_NETWORK_STATUS_ACCESS_DENIED;

--- a/node/Node.hpp
+++ b/node/Node.hpp
@@ -84,7 +84,7 @@ public:
 		volatile int64_t *nextBackgroundTaskDeadline);
 	ZT_ResultCode processBackgroundTasks(void *tptr,int64_t now,volatile int64_t *nextBackgroundTaskDeadline);
 	ZT_ResultCode join(uint64_t nwid,void *uptr,void *tptr);
-	ZT_ResultCode leave(uint64_t nwid,void **uptr,void *tptr);
+	ZT_ResultCode leave(uint64_t nwid,void **uptr,void *tptr, bool permanent);
 	ZT_ResultCode multicastSubscribe(void *tptr,uint64_t nwid,uint64_t multicastGroup,unsigned long multicastAdi);
 	ZT_ResultCode multicastUnsubscribe(uint64_t nwid,uint64_t multicastGroup,unsigned long multicastAdi);
 	ZT_ResultCode orbit(void *tptr,uint64_t moonWorldId,uint64_t moonSeed);

--- a/one.cpp
+++ b/one.cpp
@@ -139,6 +139,8 @@ static void cliPrintHelp(const char *pn,FILE *out)
 	fprintf(out,"  listnetworks            - List all networks" ZT_EOL_S);
 	fprintf(out,"  join <network ID>          - Join a network" ZT_EOL_S);
 	fprintf(out,"  leave <network ID>         - Leave a network" ZT_EOL_S);
+	fprintf(out,"  enable <network>           - Enables a network" ZT_EOL_S);
+	fprintf(out,"  disable <network>          - Disables a network" ZT_EOL_S);
 	fprintf(out,"  set <network ID> <setting> - Set a network setting" ZT_EOL_S);
 	fprintf(out,"  get <network ID> <setting> - Get a network setting" ZT_EOL_S);
 	fprintf(out,"  listmoons               - List moons (federated root sets)" ZT_EOL_S);
@@ -842,6 +844,66 @@ static int cli(int argc,char **argv)
 			return 0;
 		} else {
 			printf("%u %s %s" ZT_EOL_S,scode,command.c_str(),responseBody.c_str());
+			return 1;
+		}
+	} else if (command == "enable") {
+		if (arg1.length() != 16) {
+			printf("invalid network id" ZT_EOL_S);
+			return 2;
+		}
+		requestHeaders["Content-Type"] = "application/json";
+		requestHeaders["Content-Length"] = "2";
+		unsigned int scode = Http::POST(
+			1024 * 1024 * 16,
+			60000,
+			(const struct sockaddr*)&addr,
+			(std::string("/enable/") + arg1).c_str(),
+			requestHeaders,
+			"{}",
+			2,
+			responseHeaders,
+			responseBody);
+		if (scode == 200) {
+			if (json) {
+				printf("%s", cliFixJsonCRs(responseBody).c_str());
+			}
+			else {
+				printf("200 enable OK" ZT_EOL_S);
+			}
+		return 0;
+		}
+		else {
+			printf("%u %s %s" ZT_EOL_S, scode, command.c_str(), responseBody.c_str());
+			return 1;
+		}
+	} else if (command == "disable") {
+		if (arg1.length() != 16) {
+			printf("invalid network id" ZT_EOL_S);
+			return 2;
+		}
+		requestHeaders["Content-Type"] = "application/json";
+		requestHeaders["Content-Length"] = "2";
+		unsigned int scode = Http::POST(
+			1024 * 1024 * 16,
+			60000,
+			(const struct sockaddr*)&addr,
+			(std::string("/disable/") + arg1).c_str(),
+			requestHeaders,
+			"{}",
+			2,
+			responseHeaders,
+			responseBody);
+		if (scode == 200) {
+			if (json) {
+				printf("%s", cliFixJsonCRs(responseBody).c_str());
+			}
+			else {
+				printf("200 disable OK" ZT_EOL_S);
+			}
+			return 0;
+		}
+		else {
+			printf("%u %s %s" ZT_EOL_S, scode, command.c_str(), responseBody.c_str());
 			return 1;
 		}
 	} else if (command == "listmoons") {

--- a/service/OneService.hpp
+++ b/service/OneService.hpp
@@ -91,6 +91,11 @@ public:
 		 * Allow configuration of DNS for the network
 		 */
 		bool allowDNS;
+
+		/**
+		 * A disabled network will not be loaded, but does still exist and can be re-enabled without destroying and re-creating network adapters on Windows
+		 */
+		bool disabled;
 	};
 
 	/**


### PR DESCRIPTION
So I'm mostly opening this PR because of recent popularity in issue #659. I originally did not intend to open this PR before 2.0 (e.g because of the UI changes and I also believe 2.0 will have stuff rewritten in Go?), but here we go anyway.

## Description

This PR introduces the concept of a _disabled_ network. Disabled networks behave like the user left them, except that local config data and the TAP interface is still retained (in an offline state).

This feature is useful when users do not always want to be part of a network. In some scenarios, users might want to temporarily leave a network, with the intention of re-joining (minutes/days/weeks/months) later. In this case ZeroTier's deleting of TAP interfaces (as well as the local config) is not desired. For these use-cases, networks can now be disabled. The old "leave the network and destroy everything" behaviour still exists, this is implemented as an optional feature.

The PR adds to new CLI commands (and corresponding HTTP endpoints in the service):

```
zerotier-cli enable <network>  - Enables a network
zerotier-cli disable <network> - Disables a network
```

Joining or leaving a disabled network won't work. In order to rejoin a disabled network, it must
be re-enabled instead (disabling & enabling also auto-leaves/joins networks as appropriate).

This exact behaviour is up to discussion, and was mostly implemented because it was easier this way.

Disabled networks remain disabled, even across restarts, until enabled again via the
appropriate command.

In order to be really useful for users, the ZeroTier UI should also enable usage of this feature. However, since that is now a different project, a different PR would be needed for this. I'm also not experienced in Rust, so not sure if I will be able to make a PR to the UI project.

## Technical details

The PR adds a new local config object which stores the disabled state (true/false). On startup, if the disabled state is true, the network will be brought down again immediatly after loading it (this currently relies on some magic error signaling). The node no longer considers itself to be a member of this network. As soon as the network is re-enabled again, the node rejoins the network (and the TAP is brought up again). Disabling a network brings down the TAP interface and the node leaves the network, but the TAP as well as the local config is not destroyed.

A few changes to existing code were required:

- Saving of network settings assumed that the network would exist in memory and would bail out if this wasn't the case. In order to change settings on a disabled network (which is not loaded at that time), this had to be changed to also allow changes to networks not currently joined by the node.
- Loading of the local network config was previously inline and is now in its own function, to avoid code duplication.

## Testing

I've been using this code (older commits, but functionally identical) in my fork of ZeroTier for over a year now, and I haven't seen many issues with the code, though I've never considered it production-ready. I have only ever tried this code under Windows.