### PR TITLE
Fix multicast flag on linux interfaces.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,7 @@
 ZeroTier Release Notes
 ======
+# 2021-11-00 -- Version 1.8.2
+ * Fix multicast on linux.
 
 # 2021-10-28 -- Version 1.8.1
 

--- a/osdep/LinuxEthernetTap.cpp
+++ b/osdep/LinuxEthernetTap.cpp
@@ -213,6 +213,7 @@ LinuxEthernetTap::LinuxEthernetTap(
 			return;
 		}
 
+		ifr.ifr_flags |= IFF_MULTICAST;
 		ifr.ifr_flags |= IFF_UP;
 		if (ioctl(sock,SIOCSIFFLAGS,(void *)&ifr) < 0) {
 			::close(sock);


### PR DESCRIPTION
When we re-ordered the way the interfaces come up, this flag
stopped getting set automatically.

see 9374e45449ffe5c377e4cb2a346129ec598eeea9
and github issue #1477