### PR TITLE
Adding snapcraft 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,16 @@ attic/world/*.c25519
 attic/world/mkworld
 workspace/
 workspace2/
+
+#snapcraft specifics
+/parts/
+/stage/
+/prime/
+
+*.snap
+
+.snapcraft
+__pycache__
+*.pyc
+*_source.tar.bz2
+snap/.snapcraft

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,70 @@
+name: zerotier
+summary: ZeroTier is a software-based managed Ethernet switch for planet Earth.
+description: |
+  It erases the LAN/WAN distinction and makes VPNs, tunnels, proxies, and other kludges arising from the inflexible nature of physical networks obsolete. Everything is encrypted end-to-end and traffic takes the most direct (peer to peer) path available.
+  This snap contains ZeroTier One, a service that provides ZeroTier network connectivity and makes joining virtual networks as easy as joining IRC or Slack channels.
+  Visit ZeroTier's site for more information and pre-built binary packages. Apps for Android and iOS are available for free in the Google Play and Apple app stores.
+  Install
+    sudo snap install zerotier
+  Join your network
+    sudo zerotier.cli join 8056c2e21c000001
+    sudo zerotier.cli status
+  Approve your new node in ZeroTier Central (https://my.zerotier.com)! Welcome online!
+  
+adopt-info: one
+confinement: strict
+grade: stable
+base: core18
+
+apps:
+  one:
+    # Add -U to prevent attempting to drop privileges since snaps have their
+    # own containment mechanism. Otherwise, if a user named "zerotier-one"
+    # exists on the system, the setgid or related calls will fail.
+    command: usr/sbin/zerotier-one -U
+    daemon: simple
+    plugs:
+      - network
+      - network-bind
+      - network-control
+
+  cli:
+    command: usr/sbin/zerotier-cli
+    plugs:
+      - network
+
+  idtool:
+    command: usr/sbin/zerotier-idtool
+    plugs:
+      - network
+
+layout:
+  /var/lib/zerotier-one:
+    bind: $SNAP_COMMON
+
+parts:
+  one:
+    plugin: make
+    source: .
+    source-type: git
+    build-packages:
+      - build-essential
+      - libc++-dev
+    make-parameters:
+      - CXX=g++
+    filesets:
+      binaries:
+        - usr/sbin/zerotier-one
+        - usr/sbin/zerotier-cli
+        - usr/sbin/zerotier-idtool
+    prime:
+      - $binaries
+    override-build: |
+      snapcraftctl build
+      # Grab the version string from the newly-compiled binary.
+      snapcraftctl set-version "$(./zerotier-one -v)"
+slots:
+  zerotier-control:
+    interface: content
+    read:
+      - $SNAP_COMMON


### PR DESCRIPTION
This PR add snapcraft file required by snapcraft.

I chose core18 for it's compatibility with i386 architecture, since core20 drop its support, I though to have the more compatible system since there are some people using it.

Cheers! :beers: 