### PR TITLE
removing source-type from snapcraft

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -46,7 +46,6 @@ parts:
   one:
     plugin: make
     source: .
-    source-type: git
     build-packages:
       - build-essential
       - libc++-dev


### PR DESCRIPTION
Unnecessary since now the source it's local