### PR TITLE
Proposed fix for "path amnesia"

### DIFF
--- a/include/ZeroTierOne.h
+++ b/include/ZeroTierOne.h
@@ -163,7 +163,7 @@ extern "C" {
 /**
  * Maximum number of direct network paths to a given peer
  */
-#define ZT_MAX_PEER_NETWORK_PATHS 16
+#define ZT_MAX_PEER_NETWORK_PATHS 64
 
 /**
  * Maximum number of path configurations that can be set

--- a/node/Peer.cpp
+++ b/node/Peer.cpp
@@ -118,26 +118,66 @@ void Peer::received(
 		}
 
 		if ( (!havePath) && RR->node->shouldUsePathForZeroTierTraffic(tPtr,_id.address(),path->localSocket(),path->address()) ) {
+
+			/**
+			 * First, fill all free slots before attempting to replace a path
+			 *  - If the above fails, attempt to replace the path that has been dead the longest
+			 *  - If there are no free slots, and no dead paths (unlikely), then replace old path most similar to new path
+			 *  - If all of the above fails to yield a suitable replacement. Replace first path found to have lower `(quality / priority)`
+			 */
+
 			if (verb == Packet::VERB_OK) {
 				Mutex::Lock _l(_paths_m);
-
 				unsigned int replacePath = ZT_MAX_PEER_NETWORK_PATHS;
+				uint64_t maxScore = 0;
+				uint64_t currScore;
 				long replacePathQuality = 0;
+				bool foundFreeSlot = false;
+
 				for(unsigned int i=0;i<ZT_MAX_PEER_NETWORK_PATHS;++i) {
+					currScore = 0;
 					if (_paths[i].p) {
-						if ( (!_paths[i].p->alive(now)) || _paths[i].p->address().ipsEqual(path->address()) ) {
-							replacePath = i;
-							break;
-						} else {
-							const long q = _paths[i].p->quality(now) / _paths[i].priority;
-							if (q > replacePathQuality) {
-								replacePathQuality = q;
-								replacePath = i;
+						// Reward dead paths
+						if (!_paths[i].p->alive(now)) {
+							currScore = _paths[i].p->age(now) / 1000;
+						}
+						// Reward as similarity increases
+						if (_paths[i].p->address().ipsEqual(path->address())) {
+							currScore++;
+							if (_paths[i].p->address().port() == path->address().port()) {
+								currScore++;
+								if (_paths[i].p->localSocket() == path->localSocket()) {
+									currScore++; // max score (3)
+								}
 							}
 						}
-					} else {
+						// If best so far, mark for replacement
+						if (currScore > maxScore) {
+							maxScore = currScore;
+							replacePath = i;
+						}
+					}
+					else {
+						foundFreeSlot = true;
 						replacePath = i;
 						break;
+					}
+				}
+				if (!foundFreeSlot) {
+					if (maxScore > 3) {
+						// Do nothing. We found a dead path and have already marked it as a candidate
+					}
+					// If we couldn't find a replacement by matching, replacing a dead path, or taking a free slot, then replace by quality
+					else if (maxScore == 0) {
+						for(unsigned int i=0;i<ZT_MAX_PEER_NETWORK_PATHS;++i) {
+							if (_paths[i].p) {
+								const long q = _paths[i].p->quality(now) / _paths[i].priority;
+								if (q > replacePathQuality) {
+									replacePathQuality = q;
+									replacePath = i;
+								}
+							}
+						}
 					}
 				}
 


### PR DESCRIPTION
## Current behavior

Under ordinary circumstances upon receipt of a packet from a peer a local client will check whether the *path carrying that packet* is a pre-existing `Path` object. If it is, it will not re-learn this path. This is correct behavior.

However, if a packet is received on a path not currently in the `_paths` array it will begin a process of trying to determine what pre-existing path this new path can replace. Not only is this next process engaged prematurely but it also doesn't take into account the following situation:

 - New path matches physical IP address of existing path but not `port` or underlying `listening sockets`

This results in ZT re-learning the "same" path and overwriting existing paths repeatedly. A simple example:


- ZT learns `1.2.3.4:9993`
- ZT writes this Path into `_paths[0]`
- ZT learns of `1.2.3.4:45556`
- ZT detects that this `Path` object is not currently in `_paths` and begins the replacement process. This is correct, but neglects to check the `port`. A similar error can be made even if the ports are the same if the `listening socket` isn't considered!
- ZT finds a path in `_paths` with a matching IP and overwrites that path with the new path

The resulting `_paths` structure is now:

```
_paths[0] = 1.2.3.4:45556
```

Where it should be:

```
_paths[0] = 1.2.3.4:9993
_paths[0] = 1.2.3.4:45556
```

The problem begins when ZT re-encounters `1.2.3.4:9993`. Currently it would re-re-learn the "same" path and overwrite `_paths[0]` again. This loop continues indefinitely. Between any two peers there are up to `9` possible "paths":

```
1.2.3.4 : 9993  : listen-sock-0 (incoming in port 9993)
1.2.3.4 : 9993  : listen-sock-1 (incoming in port 20000)
1.2.3.4 : 9993  : listen-sock-2 (incoming in port 45000)

1.2.3.4 : 20000 : listen-sock-0 (incoming in port 9993)
1.2.3.4 : 20000 : listen-sock-1 (incoming in port 20000)
1.2.3.4 : 20000 : listen-sock-2 (incoming in port 45000)

1.2.3.4 : 45000 : listen-sock-0 (incoming in port 9993)
1.2.3.4 : 45000 : listen-sock-1 (incoming in port 20000)
1.2.3.4 : 45000 : listen-sock-2 (incoming in port 45000)
```

Simply adding a second WAN interface doubles this number to `18`.

## Proposed new behavior:

- First, fill all free slots in `_paths` before attempting to replace anything
- If above fails, attempt to replace the path that has been dead the longest
- If no free slots, and no dead paths (unlikely), then replace old path most similar to new path
- If all of the above fails to yield a suitable replacement. Replace first found to have lower `(quality / priority)`

With this new behavior one side-effect is that the `_paths` array contains more entries. So we should considering increasing `ZT_MAX_PEER_NETWORK_PATHS` from `16` to `64`.
