### PR TITLE
Prevent arithmetic error on interface change.

### DIFF
--- a/node/Bond.cpp
+++ b/node/Bond.cpp
@@ -488,6 +488,10 @@ int32_t Bond::generateQoSPacket(int pathIdx, int64_t now, char* qosBuffer)
 
 bool Bond::assignFlowToBondedPath(SharedPtr<Flow>& flow, int64_t now)
 {
+        if (! _numBondedPaths) {
+                log("unable to assign flow %x (bond has no links)\n", flow->id);
+                return false;
+        }
 	unsigned int idx = ZT_MAX_PEER_NETWORK_PATHS;
 	if (_policy == ZT_BOND_POLICY_BALANCE_XOR) {
 		idx = abs((int)(flow->id % (_numBondedPaths)));
@@ -499,10 +503,6 @@ bool Bond::assignFlowToBondedPath(SharedPtr<Flow>& flow, int64_t now)
 		Utils::getSecureRandom(&entropy, 1);
 		if (_totalBondUnderload) {
 			entropy %= _totalBondUnderload;
-		}
-		if (! _numBondedPaths) {
-			log("unable to assign flow %x (bond has no links)\n", flow->id);
-			return false;
 		}
 		/* Since there may be scenarios where a path is removed before we can re-estimate
 		relative qualities (and thus allocations) we need to down-modulate the entropy


### PR DESCRIPTION
Fix for:

Thread 1 "zerotier-one" received signal SIGFPE, Arithmetic exception.
0x00005555555d299c in ZeroTier::Bond::assignFlowToBondedPath (this=this@entry=0x5555557d6a40, flow=..., now=now@entry=1639595945030) at node/SharedPtr.hpp:87
87    node/SharedPtr.hpp: No such file or directory.
(gdb) bt
#0  0x00005555555d299c in ZeroTier::Bond::assignFlowToBondedPath (this=this@entry=0x5555557d6a40, flow=..., now=now@entry=1639595945030) at node/SharedPtr.hpp:87
#1  0x00005555555d3bda in ZeroTier::Bond::processBalanceTasks (this=this@entry=0x5555557d6a40, now=now@entry=1639595945030) at node/Bond.cpp:1128
#2  0x00005555555d77c6 in ZeroTier::Bond::processBackgroundBondTasks (this=0x5555557d6a40, tPtr=tPtr@entry=0x0, now=now@entry=1639595945030) at node/Bond.cpp:787
#3  0x00005555555d78b2 in ZeroTier::Bond::processBackgroundTasks (tPtr=tPtr@entry=0x0, now=now@entry=1639595945030) at node/Bond.cpp:185
#4  0x00005555555a8e28 in ZeroTier::Node::processBackgroundTasks (this=0x7ffff7a40010, tptr=tptr@entry=0x0, now=now@entry=1639595945030, 
    nextBackgroundTaskDeadline=nextBackgroundTaskDeadline@entry=0x55555579f2e8) at node/Node.cpp:261
#5  0x000055555566c1e7 in ZeroTier::(anonymous namespace)::OneServiceImpl::run (this=0x555555795f60) at service/OneService.cpp:900
#6  0x0000555555693396 in _OneServiceRunner::threadMain (this=0x7fffffffead0) at one.cpp:2037
#7  0x0000555555692f25 in main (argc=<optimized out>, argv=0x7fffffffecb8) at one.cpp:2325
(gdb)