### PR TITLE
[Android] Fix include for miniupnpc

### DIFF
--- a/osdep/PortMapper.cpp
+++ b/osdep/PortMapper.cpp
@@ -47,13 +47,8 @@
 #include <miniupnpc/miniupnpc.h>
 #include <miniupnpc/upnpcommands.h>
 #else
-#ifdef __ANDROID__
-#include "miniupnpc.h"
-#include "upnpcommands.h"
-#else
 #include "../ext/miniupnpc/miniupnpc.h"
 #include "../ext/miniupnpc/upnpcommands.h"
-#endif
 #endif
 
 #ifdef ZT_USE_SYSTEM_NATPMP


### PR DESCRIPTION
With the include directory for miniupnpc commented [as it is in libzt's CMakeLists.txt](https://github.com/zerotier/libzt/blob/41eb9aebc80a5f1c816fa26a06cefde9de906676/CMakeLists.txt#L93), the include path for Android shouldn't be any different than any other platform.

FYI--and I suppose you may already be somewhat aware of this--uncommenting the miniupnpc include directory causes problems when building for Android on Windows because some of the system headers use `#include <version>` which picks up the [miniupnpc VERSION file](https://github.com/zerotier/ZeroTierOne/blob/master/ext/miniupnpc/VERSION) on case insensitive filesystems.