### PR TITLE
Disable Salsa20 SSE when ZT_SALSA20_SSE=0

### DIFF
--- a/node/Salsa20.hpp
+++ b/node/Salsa20.hpp
@@ -19,6 +19,10 @@
 #define ZT_SALSA20_SSE 1
 #endif
 
+#if defined(ZT_SALSA20_SSE) && !ZT_SALSA20_SSE
+#undef ZT_SALSA20_SSE
+#endif
+
 #ifdef ZT_SALSA20_SSE
 #include <emmintrin.h>
 #endif // ZT_SALSA20_SSE


### PR DESCRIPTION
This allows us to force disable the `ZT_SALSA20_SSE` option even when `__WINDOWS__` or `__SSE__` is defined.

The 32-bit MinGW compiler for Windows doesn't support the compiler intrinsics used by the Salsa20 SSE implementation.

```
In file included from /home/runner/work/devilutionX/devilutionX/build/_deps/libzt-src/ext/ZeroTierOne/node/Salsa20.hpp:23,
                 from /home/runner/work/devilutionX/devilutionX/build/_deps/libzt-src/ext/ZeroTierOne/node/Salsa20.cpp:11:
/usr/lib/gcc/i686-w64-mingw32/9.3-win32/include/emmintrin.h: In constructor ‘_s20sseconsts::_s20sseconsts()’:
/usr/lib/gcc/i686-w64-mingw32/9.3-win32/include/emmintrin.h:1166:1: error: inlining failed in call to always_inline ‘__m128i _mm_slli_epi64(__m128i, int)’: target specific option mismatch
 1166 | _mm_slli_epi64 (__m128i __A, int __B)
      | ^~~~~~~~~~~~~~
/home/runner/work/devilutionX/devilutionX/build/_deps/libzt-src/ext/ZeroTierOne/node/Salsa20.cpp:60:28: note: called from here
   60 |   maskHi32 = _mm_slli_epi64(maskLo32, 32);
      |              ~~~~~~~~~~~~~~^~~~~~~~~~~~~~
In file included from /home/runner/work/devilutionX/devilutionX/build/_deps/libzt-src/ext/ZeroTierOne/node/Salsa20.hpp:23,
                 from /home/runner/work/devilutionX/devilutionX/build/_deps/libzt-src/ext/ZeroTierOne/node/Salsa20.cpp:11:
/usr/lib/gcc/i686-w64-mingw32/9.3-win32/include/emmintrin.h:1432:1: error: inlining failed in call to always_inline ‘__m128i _mm_shuffle_epi32(__m128i, int)’: target specific option mismatch
 1432 | _mm_shuffle_epi32 (__m128i __A, const int __mask)
      | ^~~~~~~~~~~~~~~~~
/home/runner/work/devilutionX/devilutionX/build/_deps/libzt-src/ext/ZeroTierOne/node/Salsa20.cpp:59:31: note: called from here
   59 |   maskLo32 = _mm_shuffle_epi32(_mm_cvtsi32_si128(-1), _MM_SHUFFLE(1, 0, 1, 0));
      |              ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/runner/work/devilutionX/devilutionX/build/_deps/libzt-src/ext/ZeroTierOne/node/Salsa20.hpp:23,
                 from /home/runner/work/devilutionX/devilutionX/build/_deps/libzt-src/ext/ZeroTierOne/node/Salsa20.cpp:11:
/usr/lib/gcc/i686-w64-mingw32/9.3-win32/include/emmintrin.h:1514:1: error: inlining failed in call to always_inline ‘__m128i _mm_cvtsi32_si128(int)’: target specific option mismatch
 1514 | _mm_cvtsi32_si128 (int __A)
      | ^~~~~~~~~~~~~~~~~
/home/runner/work/devilutionX/devilutionX/build/_deps/libzt-src/ext/ZeroTierOne/node/Salsa20.cpp:59:31: note: called from here
   59 |   maskLo32 = _mm_shuffle_epi32(_mm_cvtsi32_si128(-1), _MM_SHUFFLE(1, 0, 1, 0));
      |              ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```