### PR TITLE
Disable Salsa20 SSE on MinGW 32-bit compiler

### DIFF
--- a/node/Salsa20.hpp
+++ b/node/Salsa20.hpp
@@ -15,7 +15,7 @@
 #include "Constants.hpp"
 #include "Utils.hpp"
 
-#if (!defined(ZT_SALSA20_SSE)) && (defined(__SSE2__) || defined(__WINDOWS__))
+#if (!defined(ZT_SALSA20_SSE)) && (defined(__SSE2__) || (defined(__WINDOWS__) && !defined(__MINGW32__)))
 #define ZT_SALSA20_SSE 1
 #endif
 


### PR DESCRIPTION
This fixes the error described in #1530 by disabling Salsa20 SSE on the 32-bit MinGW compiler.

It may be worth noting that both the 64-bit and 32-bit MinGW compilers define the `__MINGW32__` variable, but the 64-bit compiler also defines `__SSE2__` so this works as expected on both.