### PR TITLE
Windows interface and route metrics

### DIFF
--- a/osdep/WindowsEthernetTap.cpp
+++ b/osdep/WindowsEthernetTap.cpp
@@ -568,6 +568,10 @@ WindowsEthernetTap::WindowsEthernetTap(
 									if (RegOpenKeyExA(HKEY_LOCAL_MACHINE,"SYSTEM\\CurrentControlSet\\services\\Tcpip\\Parameters\\Interfaces",0,KEY_READ|KEY_WRITE,&tcpIpInterfaces) == ERROR_SUCCESS) {
 										DWORD enable = 0;
 										RegSetKeyValueA(tcpIpInterfaces,_netCfgInstanceId.c_str(),"EnableDHCP",REG_DWORD,&enable,sizeof(enable));
+
+										DWORD metric = 3;
+										RegSetKeyValueA(tcpIpInterfaces, _netCfgInstanceId.c_str(), "InterfaceMetric", REG_DWORD, &metric, sizeof(metric));
+
 										RegCloseKey(tcpIpInterfaces);
 									}
 


### PR DESCRIPTION
5 is the lowest metrics an interface will get based
on Windows Automatic Metrics as far as I know.
https://docs.microsoft.com/en-us/troubleshoot/windows-server/networking/automatic-metric-for-ipv4-routes

If we set our metric to 3, there's a chance Windows will
use it for broadcast traffic, and things like game discovery
will work. If the user doesn't want that, they can leave the
zerotier network or manually set the metric on their
physical interface to < 3.

For routes with "via"'s we put the metric high,
in case it overlaps with a physical route to
the same subnet.

These could be plumbed through and set via the controller or
local.conf someday, istead of being hardcoded magic numbers.