### PR TITLE
Proactively seek, and distribute external surface addresses

### DIFF
--- a/node/Peer.cpp
+++ b/node/Peer.cpp
@@ -224,6 +224,8 @@ void Peer::received(
 		if (sinceLastPush >= ((hops == 0) ? ZT_DIRECT_PATH_PUSH_INTERVAL_HAVEPATH : ZT_DIRECT_PATH_PUSH_INTERVAL)) {
 			_lastDirectPathPushSent = now;
 			std::vector<InetAddress> pathsToPush(RR->node->directPaths());
+			std::vector<InetAddress> ma = RR->sa->whoami();
+			pathsToPush.insert(pathsToPush.end(), ma.begin(), ma.end());
 			if (!pathsToPush.empty()) {
 				std::vector<InetAddress>::const_iterator p(pathsToPush.begin());
 				while (p != pathsToPush.end()) {
@@ -453,7 +455,7 @@ void Peer::sendHELLO(void *tPtr,const int64_t localSocket,const InetAddress &atA
 	if (atAddress) {
 		outp.armor(_key,false,nullptr); // false == don't encrypt full payload, but add MAC
 		RR->node->expectReplyTo(outp.packetId());
-		RR->node->putPacket(tPtr,localSocket,atAddress,outp.data(),outp.size());
+		RR->node->putPacket(tPtr,-1,atAddress,outp.data(),outp.size());
 	} else {
 		RR->node->expectReplyTo(outp.packetId());
 		RR->sw->send(tPtr,outp,false); // false == don't encrypt full payload, but add MAC

--- a/node/SelfAwareness.cpp
+++ b/node/SelfAwareness.cpp
@@ -99,6 +99,21 @@ void SelfAwareness::iam(void *tPtr,const Address &reporter,const int64_t receive
 	}
 }
 
+std::vector<InetAddress> SelfAwareness::whoami()
+{
+	std::vector<InetAddress> surfaceAddresses;
+	Mutex::Lock _l(_phy_m);
+	Hashtable< PhySurfaceKey,PhySurfaceEntry >::Iterator i(_phy);
+	PhySurfaceKey *k = (PhySurfaceKey *)0;
+	PhySurfaceEntry *e = (PhySurfaceEntry *)0;
+	while (i.next(k,e)) {
+		if (std::find(surfaceAddresses.begin(), surfaceAddresses.end(), e->mySurface) == surfaceAddresses.end()) {
+			surfaceAddresses.push_back(e->mySurface);
+		}
+	}
+	return surfaceAddresses;
+}
+
 void SelfAwareness::clean(int64_t now)
 {
 	Mutex::Lock _l(_phy_m);

--- a/node/SelfAwareness.hpp
+++ b/node/SelfAwareness.hpp
@@ -45,6 +45,13 @@ public:
 	void iam(void *tPtr,const Address &reporter,const int64_t receivedOnLocalSocket,const InetAddress &reporterPhysicalAddress,const InetAddress &myPhysicalAddress,bool trusted,int64_t now);
 
 	/**
+	 * Return all known external surface addresses reported by peers
+	 *
+	 * @return A vector of InetAddress(es)
+	 */
+	std::vector<InetAddress> whoami();
+
+	/**
 	 * Clean up database periodically
 	 *
 	 * @param now Current time


### PR DESCRIPTION
### Summary

This patch introduces a new "self-awareness" behavior which proactively queries peers for external surface addresses and distributes them via `PUSH_DIRECT_PATHS`. This has the effect of making ZT more responsive to interface changes.

### Current behavior

Previously, this type of information was only mediated via `RENDEZVOUS` and was only triggered when the client detected that it no longer had a *single alive path* to a peer. While `PUSH_DIRECT_PATHS` would correctly (and often) send local addresses, this was not the case for external addresses collected from response `HELLO`s. This would lead to situations where only one physical address would be distributed to peers. Additionally, if a new physical interface were to be made available to the client, the client would correctly bind to it but never seek information about its external mapping from a peer, and thus the new physical interface would remain unavailable for other peers to learn about until all paths on the previous interface have expired which can take *a couple of minutes*. In traditional usage of ZT this is not usually a problem, but it becomes a problem in the following scenarios:

 - Network interfaces go up and down while ZT is running (e.g. switching to LTE or WiFi from a wired connection)
 - Network interfaces are added or removed in multipath setups

### Proposed behavior

I propose that normal `full HELLO`s are sent not only on the first interface in use, but *all* interfaces. This causes planets to respond with a `HELLO` containing the surface address for each interface. We then collect each address using `SelfAwareness::whoami()` and distribute them via the normal `PUSH_DIRECT_PATHS` mechanism.

This potentially fixes issues #1439, #1411, and #1549
