### PR TITLE
update alpine linux release to current supported

### DIFF
--- a/dockerbuild/Dockerfile.alpine
+++ b/dockerbuild/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM alpine:3.11.3
+FROM alpine:3.15
 
 ARG go_pkg_url
 


### PR DESCRIPTION
Alpine Linux 3.11 is no longer supported.
The latest current release is 3.15.2

`alpine:3.15` will always use the latest release of 3.15 (again, currently 3.15.2)