### PR TITLE
Fix for missing dependencies in Dockerfile.release

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -13,7 +13,10 @@ FROM debian:buster
 
 COPY --from=stage zerotier-one.deb .
 
-RUN dpkg -i zerotier-one.deb && rm -f zerotier-one.deb
+RUN apt-get update -qq \
+  && apt-get install -y ./zerotier-one.deb \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -f zerotier-one.deb
 RUN echo "${VERSION}" >/etc/zerotier-version
 RUN rm -rf /var/lib/zerotier-one
 


### PR DESCRIPTION
When building my own Docker image of ZeroTier with the latest version 1.8.6 using the `docker build -f Dockerfile.release -t zerotier/zerotier:latest --build-arg VERSION=1.8.6 .` command, I noticed it failed due to missing dependencies related to SSL that the _Dockerfile.release_ did not take into account:

```console
dpkg: dependency problems prevent configuration of zerotier-one:
 zerotier-one depends on libssl1.1 (>= 1.1.1); however:
  Package libssl1.1 is not installed.
 zerotier-one depends on openssl; however:
  Package openssl is not installed.

dpkg: error processing package zerotier-one (--install):
 dependency problems - leaving unconfigured
Errors were encountered while processing:
 zerotier-one
```

To fix this error, I've decided to make use of the _APT_ package manager instead of the _DPKG_ tool to install the _DEB_ package, thus resolving the dependencies automatically and successfully creating the Docker image.