### PR TITLE
Add `zerotier-cli info` output to Docker logs

### DIFF
--- a/entrypoint.sh.release
+++ b/entrypoint.sh.release
@@ -77,6 +77,8 @@ EOF
 
 chmod +x /healthcheck.sh
 
+echo "zerotier-cli info: $(zerotier-cli info)"
+
 echo "Sleeping infinitely"
 while true
 do


### PR DESCRIPTION
When I first bring up the container, I want to know I'm approving the join request for the right node. I can get the node's ZT address by manually executing `zerotier-cli info` in the node (e.g. with `docker-compose exec zerotier zerotier-cli info`) but just having it in the logs to start with is very convenient.

Example logs:
```
> docker-compose logs 
Attaching to zerotier-container-stack-first-party-with-tweaks_whoami_1, zerotier-container-stack-first-party-with-tweaks_zerotier_1
whoami_1    | Starting up on port 80
zerotier_1  | Configuring networks to join
zerotier_1  | joining networks: 233ccaac27dbf50c
zerotier_1  | Configuring join for 233ccaac27dbf50c
zerotier_1  | starting zerotier
zerotier_1  | cat: /var/lib/zerotier-one/zerotier-one.pid: No such file or directory
zerotier_1  | cat: /var/lib/zerotier-one/zerotier-one.pid: No such file or directory
zerotier_1  | zerotier hasn't started, waiting a second
zerotier_1  | Writing healthcheck for networks: 233ccaac27dbf50c
zerotier_1  | zerotier-cli info: 200 info 7aa83280ef 1.8.6 OFFLINE
zerotier_1  | Sleeping infinitely
```