### PR TITLE
prettify the entrypoint log output

### DIFF
--- a/entrypoint.sh.release
+++ b/entrypoint.sh.release
@@ -33,29 +33,57 @@ fi
 mkztfile zerotier-one.port 0600 "9993"
 
 killzerotier() {
-  echo "Killing zerotier"
+  log "Killing zerotier"
   kill $(cat /var/lib/zerotier-one/zerotier-one.pid 2>/dev/null)
   exit 0
 }
 
+log_header() {
+  echo -n "\r=>"
+}
+
+log_detail_header() {
+  echo -n "\r===>"
+}
+
+log() {
+  echo "$(log_header)" "$@"
+}
+
+log_params() {
+  title=$1
+  shift
+  log "$title" "[$@]"
+}
+
+log_detail() {
+  echo "$(log_detail_header)" "$@"
+}
+
+log_detail_params() {
+  title=$1
+  shift
+  log_detail "$title" "[$@]"
+}
+
 trap killzerotier INT TERM
 
-echo "Configuring networks to join"
+log "Configuring networks to join"
 mkdir -p /var/lib/zerotier-one/networks.d
 
-echo "joining networks: $@"
+log_params "Joining networks:" $@
 for i in "$@"
 do
-  echo "Configuring join for $i"
+  log_detail_params "Configuring join:" "$i"
   touch "/var/lib/zerotier-one/networks.d/${i}.conf"
 done
 
-echo "starting zerotier"
+log "Starting ZeroTier"
 nohup /usr/sbin/zerotier-one &
 
 while ! grepzt
 do
-  echo "zerotier hasn't started, waiting a second"
+  log_detail "ZeroTier hasn't started, waiting a second"
 
   if [ -f nohup.out ]
   then
@@ -65,7 +93,7 @@ do
   sleep 1
 done
 
-echo "Writing healthcheck for networks: $@"
+log_params "Writing healthcheck for networks:" $@
 
 cat >/healthcheck.sh <<EOF
 #!/bin/bash
@@ -77,9 +105,9 @@ EOF
 
 chmod +x /healthcheck.sh
 
-echo "zerotier-cli info: $(zerotier-cli info)"
+log_params "zerotier-cli info:" "$(zerotier-cli info)"
 
-echo "Sleeping infinitely"
+log "Sleeping infinitely"
 while true
 do
   sleep 1


### PR DESCRIPTION
```
=> Configuring networks to join
=> Joining networks: [abcdefdeadbeef00 cabacabacabacaba]
===> Configuring join: [abcdefdeadbeef00]
===> Configuring join: [cabacabacabacaba]
=> Starting ZeroTier
===> ZeroTier hasn't started, waiting a second
=> Writing healthcheck for networks: [abcdefdeadbeef00 cabacabacabacaba]
=> zerotier-cli info: [200 info e1facddce2 1.8.7 OFFLINE]
=> Sleeping infinitely
=> Killing zerotier
```