### PR TITLE
Fix cargo home directory (was previously hard-coded to /root)

### DIFF
--- a/make-linux.mk
+++ b/make-linux.mk
@@ -393,7 +393,7 @@ ifeq ($(ZT_SSO_SUPPORTED), 1)
 ifeq ($(ZT_EMBEDDED),)
 zeroidc:	FORCE
 #	export PATH=/root/.cargo/bin:$$PATH; cd zeroidc && cargo build -j1 $(RUSTFLAGS)
-	export PATH=/root/.cargo/bin:$$PATH; cd zeroidc && cargo build $(RUSTFLAGS)
+	export PATH=/${HOME}/.cargo/bin:$$PATH; cd zeroidc && cargo build $(RUSTFLAGS)
 endif
 else
 zeroidc:


### PR DESCRIPTION
Signed-off-by: Erik Hollensbe <git@hollensbe.org>