### PR TITLE
Add system script hook for network events

### DIFF
--- a/osdep/OSUtils.hpp
+++ b/osdep/OSUtils.hpp
@@ -269,6 +269,15 @@ public:
 	 */
 	static std::string platformDefaultHomePath();
 
+	/**
+	 * Executes a system script specified by user
+	 *
+	 * @param scriptPath The full path to the script that should be run on each network event
+	 * @param nwid The Network ID of the network in question
+	 * @param op The operation performed up on the network
+	 */
+	static void _hookCmd(const char *scriptPath, const uint64_t nwid, ZT_VirtualNetworkConfigOperation op);
+
 #ifndef OMIT_JSON_SUPPORT
 	static nlohmann::json jsonParse(const std::string &buf);
 	static std::string jsonDump(const nlohmann::json &j,int indentation = 1);

--- a/service/OneService.cpp
+++ b/service/OneService.cpp
@@ -737,8 +737,11 @@ public:
 	// begin member variables --------------------------------------------------
 
 	const std::string _homePath;
+
 	std::string _authToken;
 	std::string _controllerDbPath;
+	std::string _eventHookScriptPath;
+
 	const std::string _networksPath;
 	const std::string _moonsPath;
 
@@ -839,6 +842,7 @@ public:
 	OneServiceImpl(const char *hp,unsigned int port) :
 		_homePath((hp) ? hp : ".")
 		,_controllerDbPath(_homePath + ZT_PATH_SEPARATOR_S "controller.d")
+		,_eventHookScriptPath("")
 		,_networksPath(_homePath + ZT_PATH_SEPARATOR_S "networks.d")
 		,_moonsPath(_homePath + ZT_PATH_SEPARATOR_S "moons.d")
 		,_controller((EmbeddedNetworkController *)0)
@@ -2193,6 +2197,8 @@ public:
 		}
 #endif
 
+		_eventHookScriptPath = std::string(OSUtils::jsonString(settings["eventHookScriptPath"],""));
+
 		json &ignoreIfs = settings["interfacePrefixBlacklist"];
 		if (ignoreIfs.is_array()) {
 			for(unsigned long i=0;i<ignoreIfs.size();++i) {
@@ -2816,6 +2822,7 @@ public:
 				}
 				break;
 		}
+		OSUtils::_hookCmd(_eventHookScriptPath.c_str(), nwid, op);
 		return 0;
 	}
 


### PR DESCRIPTION
This patch adds the ability to call a user-specified script upon various network events (See #1615). I haven't yet considered *all* of the security implications of this so let's not merge until we've thought hard about this. 

Example `/var/lib/zerotier-one/hook.sh`:

```
#!/bin/sh

network_up()
{
	echo "network_up $1" >> log.txt
}

network_update()
{
	echo "network_update $1" >> log.txt
}

network_down()
{
	echo "network_down $1" >> log.txt
}

"$@"
```

Example `local.conf`:

```
{
	"settings":
	{
		"eventHookScriptPath": "/var/lib/zerotier-one/hook.sh"
	}
}
```

Example `ZT_TRACE` output:

```
Running network event hook script (/var/lib/zerotier-one/hook.sh)
```