### PR TITLE
Synology Docker: update entrypoint.sh

### DIFF
--- a/pkg/synology/dsm7-docker/Dockerfile
+++ b/pkg/synology/dsm7-docker/Dockerfile
@@ -2,13 +2,12 @@
 
 FROM alpine:latest as builder
 
-RUN apk add --no-cache rust cargo
-RUN apk add  openssl-dev
-
-RUN apk add --update alpine-sdk linux-headers \
+WORKDIR /src
+RUN apk add --no-cache rust cargo \
+  && apk add  openssl-dev \
+  && apk add --update alpine-sdk linux-headers \
   && git clone --quiet https://github.com/zerotier/ZeroTierOne.git /src \
-  && git -C src reset --quiet --hard ${ZTO_COMMIT} \
-  && cd /src \
+  && git reset --quiet --hard ${ZTO_COMMIT} \
   && make -f make-linux.mk
 
 FROM alpine:latest
@@ -18,6 +17,7 @@ LABEL description="ZeroTier One docker image for Synology NAS"
 RUN apk add --update --no-cache bash jq libc6-compat libstdc++
 
 EXPOSE 9993/udp
+ENV MAX_WAIT_SECS SLEEP_TIME
 
 COPY --from=builder /src/zerotier-one /usr/sbin/
 RUN mkdir -p /var/lib/zerotier-one \

--- a/pkg/synology/dsm7-docker/entrypoint.sh
+++ b/pkg/synology/dsm7-docker/entrypoint.sh
@@ -1,29 +1,55 @@
 #!/bin/bash
 
+set -uo pipefail
+
+trap 'trap " " SIGTERM; kill 0; wait' SIGTERM SIGQUIT SIGINT
+
+echo "Starting Zerotier-One"
 zerotier-one -d
 
-# Wait for ZT service to come online before attempting queries
+# Waiting for ZT service to come online before attempting queries
 sleep 15
 
+(
+echo "Starting route helper"
 while true
 do
-    NETWORK_COUNT=$(zerotier-cli -j listnetworks | jq -r '. | length')
-    if [ "$NETWORK_COUNT" -gt 0 ]; then
+    if ! NETWORK_LIST="$(zerotier-cli -j listnetworks)"
+    then
+      echo "Route helper: $NETWORK_LIST" >&2
+      exit 1
+    fi
+    NETWORK_COUNT="$(jq -r '. | length' <<< "$NETWORK_LIST")"
+    if [[ "$NETWORK_COUNT" -gt 0 ]]
+    then
         for ((j=0; j<=$((NETWORK_COUNT-1)); j++))
         do
-            ROUTE_COUNT=$(zerotier-cli -j listnetworks | jq -r '.['$j'].routes | length')
+            ALLOW_DEFAULT="$(jq -r '.['$j'].allowDefault' <<< "$NETWORK_LIST")"
+            ROUTE_COUNT="$(jq -r '.['$j'].routes | length' <<< "$NETWORK_LIST")"
             for ((k=0; k<=$((ROUTE_COUNT-1)); k++))
             do
-                ROUTE=$(zerotier-cli -j listnetworks | jq -r '.['$j'].routes['$k'].target')
-                EXIST=$(ip route show $ROUTE | wc -l)
-                if [ $EXIST -eq 0 ];
+                ROUTE="$(jq -r '.['$j'].routes['$k'].target' <<< "$NETWORK_LIST")"
+                if [[ -n "$ROUTE" ]]
                 then
-                    IFNAME=$(zerotier-cli -j listnetworks | jq -r '.['$j'] | .portDeviceName')
-                    ip route add $ROUTE dev $IFNAME
-                    # Routes will be deleted when ZT brings the interface down
+                    # check if route is default and allowDefault enabled for this network
+                    if [[ "$ROUTE" == "0.0.0.0/0" && "$ALLOW_DEFAULT" == "false" ]]
+                    then
+                      continue
+                    fi
+                    EXIST="$(ip -o route show "$ROUTE")"
+                    if [[ -z "${EXIST}" ]]
+                    then
+                        IFNAME="$(jq -r '.['$j'] | .portDeviceName' <<< "$NETWORK_LIST")"
+                        echo " Adding route $ROUTE to dev $IFNAME"
+                        ip route add "$ROUTE" dev "$IFNAME"
+                        # Routes will be deleted when ZT brings the interface down
+                    fi
                 fi
             done
         done
-        sleep 15
     fi
-done
+    sleep 15
+done ) &
+
+wait
+


### PR DESCRIPTION
- propagate TERM/QUIT/INT signals
- add some basic logging
- check for unbound variables
- update "route helper"
   - run as subshell, exit if zerotier-one is unavailable so pod can be restarted
   - only call `zerotier-cli` once, avoids race conditions
   - only add default routes if allowDefault is enabled for that network
   - add some more error handling
   - sleep after all networks are processed