### PR TITLE
fix the network deletion failed

### DIFF
--- a/controller/PostgreSQL.cpp
+++ b/controller/PostgreSQL.cpp
@@ -330,7 +330,7 @@ void PostgreSQL::eraseNetwork(const uint64_t networkId)
 	waitForReady();
 	Utils::hex(networkId, tmp2);
 	std::pair<nlohmann::json,bool> tmp;
-	tmp.first["id"] = tmp2;
+	tmp.first["nwid"] = tmp2;
 	tmp.first["objtype"] = "_delete_network";
 	tmp.second = true;
 	_commitQueue.post(tmp);


### PR DESCRIPTION
`Error deleting network: [json.exception.type_error.302] type must be string, but is null`

https://github.com/zerotier/ZeroTierOne/blob/dev/controller/PostgreSQL.cpp#L1481-L1491