### PR TITLE
fix erase network failed

### DIFF
--- a/controller/PostgreSQL.cpp
+++ b/controller/PostgreSQL.cpp
@@ -1483,7 +1483,7 @@ void PostgreSQL::commitThread()
 				try {
 					pqxx::work w(*c->c);
 
-					std::string networkId = config["nwid"];
+					std::string networkId = config["id"];
 
 					pqxx::result res = w.exec_params0("UPDATE ztc_network SET deleted = true WHERE id = $1",
 						networkId);


### PR DESCRIPTION
`Error deleting network: [json.exception.type_error.302] type must be string, but is null`

https://github.com/zerotier/ZeroTierOne/blob/dev/controller/PostgreSQL.cpp#L1481-L1491