### PR TITLE
Add missing <algorithm> include

### DIFF
--- a/node/SHA512.cpp
+++ b/node/SHA512.cpp
@@ -1,5 +1,7 @@
 // This code is public domain, taken from a PD crypto source file on GitHub.
 
+#include <algorithm>
+
 #include "SHA512.hpp"
 #include "Utils.hpp"
 


### PR DESCRIPTION
This is required for building under VS2017 since `std:min()` is being used.