### PR TITLE
Prevent re-armoring of packets when in multipath broadcast mode

### DIFF
--- a/node/Packet.hpp
+++ b/node/Packet.hpp
@@ -1250,6 +1250,14 @@ public:
 	}
 
 	/**
+	 * @return Whether this packet is currently encrypted
+	 */
+	inline bool isEncrypted() const
+	{
+		return (cipher() == ZT_PROTO_CIPHER_SUITE__C25519_POLY1305_SALSA2012) || (cipher() == ZT_PROTO_CIPHER_SUITE__AES_GMAC_SIV);
+	}
+
+	/**
 	 * Set this packet's cipher suite
 	 */
 	inline void setCipher(unsigned int c)

--- a/node/Switch.cpp
+++ b/node/Switch.cpp
@@ -1045,7 +1045,9 @@ void Switch::_sendViaSpecificPath(void *tPtr,SharedPtr<Peer> peer,SharedPtr<Path
 	if (trustedPathId) {
 		packet.setTrusted(trustedPathId);
 	} else {
-		packet.armor(peer->key(),encrypt,peer->aesKeysIfSupported());
+		if (!packet.isEncrypted()) {
+			packet.armor(peer->key(),encrypt,peer->aesKeysIfSupported());
+		}
 		RR->node->expectReplyTo(packet.packetId());
 	}
 


### PR DESCRIPTION
Add a function `isEncrypted` to `Packet` that checks for the presence of set cipher flags. Then check this state in `Switch` before armoring a packet. Packets will only be armored if neither of the cipher flags are set. Normally there would never be a situation where this is needed but in the multipath `broadcast` scenario a packet will be armored and sent on multiple interfaces. It only needs to be armored once. 