### PR TITLE
Expose surface addresses in info json

### DIFF
--- a/node/Node.hpp
+++ b/node/Node.hpp
@@ -35,6 +35,7 @@
 #include "NetworkController.hpp"
 #include "Hashtable.hpp"
 #include "Bond.hpp"
+#include "SelfAwareness.hpp"
 
 // Bit mask for "expecting reply" hash
 #define ZT_EXPECTING_REPLIES_BUCKET_MASK1 255
@@ -186,6 +187,8 @@ public:
 	std::vector<World> moons() const;
 
 	inline const Identity &identity() const { return _RR.identity; }
+
+	inline const std::vector<InetAddress> SurfaceAddresses() const { return _RR.sa->whoami(); }
 
 	inline Bond *bondController() const { return _RR.bc; }
 

--- a/service/OneService.cpp
+++ b/service/OneService.cpp
@@ -1560,6 +1560,15 @@ public:
 					}
 					settings["listeningOn"] = boundAddrArray;
 
+					std::vector<InetAddress> surfaceAddrs = _node-> SurfaceAddresses();
+					auto surfaceAddrArray = json::array();
+					for (int i = 0; i < surfaceAddrs.size(); i++) {
+						char ipBuf[64] = { 0 };
+						surfaceAddrs[i].toString(ipBuf);
+						surfaceAddrArray.push_back(ipBuf);
+					}
+					settings["surfaceAddresses"] = surfaceAddrArray;
+
 #ifdef ZT_USE_MINIUPNPC
 					settings["portMappingEnabled"] = OSUtils::jsonBool(settings["portMappingEnabled"],true);
 #else


### PR DESCRIPTION
This just adds a node's "surface addresses" to the output of `zerotier-cli info -j` 


----

Surface Addresses are the addresses that
the roots report back to you.

This is helpful for troubleshooting.

If you're behind NAT, the source port is different than what zerotier is bound to.
If the list of surface address ports is larger than the list of bound addresses, you are probably behind symmetric NAT.

Anyways this can be added to later with a more simple "easy" or "hard" nat computed message somewhere.