### PR TITLE
exclude static route with via ip in route helper

### DIFF
--- a/pkg/synology/dsm7-docker/entrypoint.sh
+++ b/pkg/synology/dsm7-docker/entrypoint.sh
@@ -55,6 +55,7 @@ do
             for ((k=0; k<=$((ROUTE_COUNT-1)); k++))
             do
                 ROUTE="$(jq -r '.['$j'].routes['$k'].target' <<< "$NETWORK_LIST")"
+                VIA="$(jq -r '.['$j'].routes['$k'].via' <<< "$NETWORK_LIST")"
                 if [[ -n "$ROUTE" ]]
                 then
                     # check if route is default and allowDefault enabled for this network
@@ -63,7 +64,7 @@ do
                       continue
                     fi
                     EXIST="$(ip -o route show "$ROUTE")"
-                    if [[ -z "${EXIST}" ]]
+                    if [[ -z "${EXIST}" && "$VIA" == "null" ]]
                     then
                         IFNAME="$(jq -r '.['$j'] | .portDeviceName' <<< "$NETWORK_LIST")"
                         echo " Adding route $ROUTE to dev $IFNAME"


### PR DESCRIPTION
When adding some routes to zerotier's managed routes, the helper script will add a route rule without `via ip` to the container's ip route, so the address of the destination ip segment cannot be routed correctly within the container.
Here, based on the contents of the `routes` key in json of 
`zerotier-cli -j listnetworks`, by determining whether the `via` key has an ip address, if it is not null, helper will no longer add this route rule.

for example:

* suppose our managed routes in my.zerotier.com like this: `10.10.0.0/16 via 172.23.0.1` and a LAN `172.23.0.0/16`.
* the Route Helper script will add two routes in container like this:
  ```
  172.23.0.0/16 dev $IFNAME scope link
  10.10.0.0/16 dev $IFNAME scope link
  ```
* but the right route should be like this:
  ```  
  172.23.0.0/16 dev $IFNAME scope link
  10.10.0.0/16 via 172.23.0.1 dev $IFNAME metric 5000 //should be added by zerotier automaticlly
  ```
