### PR TITLE
Fix syntax error

### DIFF
--- a/make-bsd.mk
+++ b/make-bsd.mk
@@ -133,7 +133,7 @@ endif
 
 # Fail if system architecture could not be determined
 ifeq ($(ZT_ARCHITECTURE),999)
-ERR=$(error FATAL: architecture could not be determined from $(CC) -dumpmachine: $CC_MACH)
+ERR=$(error FATAL: architecture could not be determined from $(CC) -dumpmachine: $(CC_MACH))
 .PHONY: err
 err: ; $(ERR)
 endif


### PR DESCRIPTION
Similar previous fix:
https://github.com/zerotier/ZeroTierOne/commit/668ab8b85c169648141d961566f183cf71ae6fa6