### PR TITLE
Prevent shadowing VM routes as default route (macOS)

### DIFF
--- a/osdep/ManagedRoute.cpp
+++ b/osdep/ManagedRoute.cpp
@@ -477,7 +477,7 @@ bool ManagedRoute::sync()
 	if ((newSystemVia)&&(!newSystemDevice[0])) {
 		rtes = _getRTEs(newSystemVia,true);
 		for(std::vector<_RTE>::iterator r(rtes.begin());r!=rtes.end();++r) {
-			if ( (r->device[0]) && (strcmp(r->device,_device) != 0) ) {
+			if ( (r->device[0]) && (strcmp(r->device,_device) != 0) && r->target.netmaskBits() != 0) {
 				Utils::scopy(newSystemDevice,sizeof(newSystemDevice),r->device);
 				break;
 			}


### PR DESCRIPTION
If you have a VM host like parallels, sometimes you get these "link-level" default routes:

```
netstat -nrfinet | grep "default"
default            192.168.82.1       UGScg             en1
default            link#22            UCSIg       bridge101      !
```

(the link#22 one)

The _getRTEs function includes these routes in the list it makes as like:

device: bridge101, target: 0.0.0.0/0

If it happens to be first in the list, bridge101 gets selected as the default route.

Then Full Tunnel Mode doesn't work.

The other routes in the list are like:
device: en1 target: 192.168.1.0/24 via:  metric: 0 ifscope: 0 device: en1 target: 192.168.1.1/32 via:  metric: 0 ifscope: 0

We only need the device name from this, so either one will work.