### PR TITLE
User-configurable physical MTU for individual links

### DIFF
--- a/node/Bond.cpp
+++ b/node/Bond.cpp
@@ -184,7 +184,7 @@ SharedPtr<Link> Bond::getLinkBySocket(const std::string& policyAlias, uint64_t l
 	auto search = _interfaceToLinkMap[policyAlias].find(ifnameStr);
 	if (search == _interfaceToLinkMap[policyAlias].end()) {
 		if (createIfNeeded) {
-			SharedPtr<Link> s = new Link(ifnameStr, 0, 0, true, ZT_BOND_SLAVE_MODE_PRIMARY, "");
+			SharedPtr<Link> s = new Link(ifnameStr, 0, 0, 0, true, ZT_BOND_SLAVE_MODE_PRIMARY, "");
 			_interfaceToLinkMap[policyAlias].insert(std::pair<std::string, SharedPtr<Link> >(ifnameStr, s));
 			return s;
 		}
@@ -1253,6 +1253,7 @@ void Bond::estimatePathQuality(int64_t now)
 			if (link) {
 				int linkSpeed = link->capacity();
 				_paths[i].p->_givenLinkSpeed = linkSpeed;
+				_paths[i].p->_mtu = link->mtu();
 				maxObservedLinkCap = linkSpeed > maxObservedLinkCap ? linkSpeed : maxObservedLinkCap;
 			}
 		}

--- a/node/Bond.hpp
+++ b/node/Bond.hpp
@@ -122,9 +122,10 @@ class Link {
 	 * @param mode
 	 * @param failoverToLinkStr
 	 */
-	Link(std::string ifnameStr, uint8_t ipvPref, uint32_t capacity, bool enabled, uint8_t mode, std::string failoverToLinkStr)
+	Link(std::string ifnameStr, uint8_t ipvPref, uint16_t mtu, uint32_t capacity, bool enabled, uint8_t mode, std::string failoverToLinkStr)
 		: _ifnameStr(ifnameStr)
 		, _ipvPref(ipvPref)
+		, _mtu(mtu)
 		, _capacity(capacity)
 		, _relativeCapacity(0.0)
 		, _enabled(enabled)
@@ -227,6 +228,14 @@ class Link {
 	}
 
 	/**
+	 * @return The MTU for this link (as specified by the user.)
+	 */
+	inline uint16_t mtu()
+	{
+		return _mtu;
+	}
+
+	/**
 	 * @return The mode (e.g. primary/spare) for this link (as specified by the user.)
 	 */
 	inline uint8_t mode()
@@ -259,6 +268,11 @@ class Link {
 	 * 64: IPv6 over IPv4
 	 */
 	uint8_t _ipvPref;
+
+	/**
+	 * The physical-layer MTU for this link
+	 */
+	uint16_t _mtu;
 
 	/**
 	 * User-specified capacity of this link

--- a/node/Path.hpp
+++ b/node/Path.hpp
@@ -92,6 +92,7 @@ public:
 		_valid(true),
 		_eligible(false),
 		_bonded(false),
+		_mtu(0),
 		_givenLinkSpeed(0),
 		_relativeQuality(0),
 		_latency(0xffff),
@@ -112,6 +113,7 @@ public:
 		_valid(true),
 		_eligible(false),
 		_bonded(false),
+		_mtu(0),
 		_givenLinkSpeed(0),
 		_relativeQuality(0),
 		_latency(0xffff),
@@ -335,6 +337,11 @@ public:
 	inline unsigned int bonded() const { return _bonded; }
 
 	/**
+	 * @return Whether the user-specified MTU for this path (determined by MTU for parent link)
+	 */
+	inline unsigned int mtu() const { return _mtu; }
+
+	/**
 	 * @return Given link capacity as reported by the bonding layer
 	 */
 	inline unsigned int givenLinkSpeed() const { return _givenLinkSpeed; }
@@ -370,6 +377,7 @@ private:
 	volatile bool _valid;
 	volatile bool _eligible;
 	volatile bool _bonded;
+	volatile uint16_t _mtu;
 	volatile uint32_t _givenLinkSpeed;
 	volatile float _relativeQuality;
 

--- a/node/Switch.hpp
+++ b/node/Switch.hpp
@@ -207,7 +207,7 @@ public:
 private:
 	bool _shouldUnite(const int64_t now,const Address &source,const Address &destination);
 	bool _trySend(void *tPtr,Packet &packet,bool encrypt,int32_t flowId = ZT_QOS_NO_FLOW); // packet is modified if return is true
-	void _sendViaSpecificPath(void *tPtr,SharedPtr<Peer> peer,SharedPtr<Path> viaPath,int64_t now,Packet &packet,bool encrypt,int32_t flowId);
+	void _sendViaSpecificPath(void *tPtr,SharedPtr<Peer> peer,SharedPtr<Path> viaPath,uint16_t userSpecifiedMtu, int64_t now,Packet &packet,bool encrypt,int32_t flowId);
 
 	const RuntimeEnvironment *const RR;
 	int64_t _lastBeaconResponse;

--- a/service/OneService.cpp
+++ b/service/OneService.cpp
@@ -2068,6 +2068,7 @@ public:
 					bool enabled = OSUtils::jsonInt(link["enabled"],true);
 					uint32_t capacity = OSUtils::jsonInt(link["capacity"],0);
 					uint8_t ipvPref = OSUtils::jsonInt(link["ipvPref"],0);
+					uint16_t mtu = OSUtils::jsonInt(link["mtu"],0);
 					std::string failoverToStr(OSUtils::jsonString(link["failoverTo"],""));
 					// Mode
 					std::string linkModeStr(OSUtils::jsonString(link["mode"],"spare"));
@@ -2084,7 +2085,7 @@ public:
 						failoverToStr = "";
 						enabled = false;
 					}
-					_node->bondController()->addCustomLink(customPolicyStr, new Link(linkNameStr,ipvPref,capacity,enabled,linkMode,failoverToStr));
+					_node->bondController()->addCustomLink(customPolicyStr, new Link(linkNameStr,ipvPref,mtu,capacity,enabled,linkMode,failoverToStr));
 				}
 				std::string linkSelectMethodStr(OSUtils::jsonString(customPolicy["activeReselect"],"optimize"));
 				if (linkSelectMethodStr == "always") {

--- a/service/OneService.cpp
+++ b/service/OneService.cpp
@@ -520,7 +520,7 @@ static void _networkToJson(nlohmann::json &nj,NetworkState &ns)
 	}
 }
 
-static void _peerToJson(nlohmann::json &pj,const ZT_Peer *peer, SharedPtr<Bond> &bond)
+static void _peerToJson(nlohmann::json &pj,const ZT_Peer *peer, SharedPtr<Bond> &bond, bool isTunneled)
 {
 	char tmp[256];
 
@@ -541,6 +541,7 @@ static void _peerToJson(nlohmann::json &pj,const ZT_Peer *peer, SharedPtr<Bond> 
 	pj["latency"] = peer->latency;
 	pj["role"] = prole;
 	pj["isBonded"] = peer->isBonded;
+	pj["tunneled"] = isTunneled;
 	if (bond && peer->isBonded) {
 		pj["bondingPolicyCode"] = peer->bondingPolicy;
 		pj["bondingPolicyStr"] = Bond::getPolicyStrByCode(peer->bondingPolicy);
@@ -713,6 +714,7 @@ public:
 	PhySocket *_localControlSocket6;
 	bool _updateAutoApply;
 	bool _allowTcpFallbackRelay;
+	bool _forceTcpRelay;
 	bool _allowSecondaryPort;
 
 	unsigned int _primaryPort;
@@ -811,6 +813,7 @@ public:
 		,_localControlSocket4((PhySocket *)0)
 		,_localControlSocket6((PhySocket *)0)
 		,_updateAutoApply(false)
+		,_forceTcpRelay(false)
 		,_primaryPort(port)
 		,_udpPortPickerCounter(0)
 		,_lastDirectReceiveFromGlobal(0)
@@ -1086,7 +1089,10 @@ public:
 						if (_ports[i])
 							p[pc++] = _ports[i];
 					}
-					_binder.refresh(_phy,p,pc,explicitBind,*this);
+					if (!_forceTcpRelay) {
+						// Only bother binding UDP ports if we aren't forcing TCP-relay mode
+						_binder.refresh(_phy,p,pc,explicitBind,*this);
+					}
 					{
 						Mutex::Lock _l(_nets_m);
 						for(std::map<uint64_t,NetworkState>::iterator n(_nets.begin());n!=_nets.end();++n) {
@@ -1104,8 +1110,9 @@ public:
 				}
 
 				// Close TCP fallback tunnel if we have direct UDP
-				if ((_tcpFallbackTunnel)&&((now - _lastDirectReceiveFromGlobal) < (ZT_TCP_FALLBACK_AFTER / 2)))
+				if (!_forceTcpRelay && (_tcpFallbackTunnel) && ((now - _lastDirectReceiveFromGlobal) < (ZT_TCP_FALLBACK_AFTER / 2))) {
 					_phy.close(_tcpFallbackTunnel->sock);
+				}
 
 				// Sync multicast group memberships
 				if ((now - lastTapMulticastGroupCheck) >= ZT_TAP_CHECK_MULTICAST_INTERVAL) {
@@ -1481,7 +1488,7 @@ public:
 											if (ps[1] == "show") {
 												SharedPtr<Bond> bond = _node->bondController()->getBondByPeerId(wantp);
 												if (bond) {
-													_peerToJson(res,&(pl->peers[i]),bond);
+													_peerToJson(res,&(pl->peers[i]),bond,(_tcpFallbackTunnel != (TcpConnection *)0));
 													scode = 200;
 												} else {
 													scode = 400;
@@ -1523,6 +1530,7 @@ public:
 					}
 					json &settings = res["config"]["settings"];
 					settings["allowTcpFallbackRelay"] = OSUtils::jsonBool(settings["allowTcpFallbackRelay"],_allowTcpFallbackRelay);
+					settings["forceTcpRelay"] = OSUtils::jsonBool(settings["forceTcpRelay"],_forceTcpRelay);
 					settings["primaryPort"] = OSUtils::jsonInt(settings["primaryPort"],(uint64_t)_primaryPort) & 0xffff;
 					settings["secondaryPort"] = OSUtils::jsonInt(settings["secondaryPort"],(uint64_t)_secondaryPort) & 0xffff;
 					settings["tertiaryPort"] = OSUtils::jsonInt(settings["tertiaryPort"],(uint64_t)_tertiaryPort) & 0xffff;
@@ -1627,7 +1635,7 @@ public:
 									const uint64_t id = pl->peers[i].address;
 									bond = _node->bondController()->getBondByPeerId(id);
 								}
-								_peerToJson(pj,&(pl->peers[i]),bond);
+								_peerToJson(pj,&(pl->peers[i]),bond,(_tcpFallbackTunnel != (TcpConnection *)0));
 								res.push_back(pj);
 							}
 
@@ -1642,7 +1650,7 @@ public:
 									if (pl->peers[i].isBonded) {
 										bond = _node->bondController()->getBondByPeerId(wantp);
 									}
-									_peerToJson(res,&(pl->peers[i]),bond);
+									_peerToJson(res,&(pl->peers[i]),bond,(_tcpFallbackTunnel != (TcpConnection *)0));
 									scode = 200;
 									break;
 								}
@@ -2111,6 +2119,8 @@ public:
 
 		// bondingPolicy cannot be used with allowTcpFallbackRelay
 		_allowTcpFallbackRelay = OSUtils::jsonBool(settings["allowTcpFallbackRelay"],true);
+		_forceTcpRelay = OSUtils::jsonBool(settings["forceTcpRelay"],false);
+
 #ifdef ZT_TCP_FALLBACK_RELAY
 		_fallbackRelayAddress = InetAddress(OSUtils::jsonString(settings["tcpFallbackRelay"], ZT_TCP_FALLBACK_RELAY).c_str());
 #endif
@@ -2388,6 +2398,9 @@ public:
 
 	inline void phyOnDatagram(PhySocket *sock,void **uptr,const struct sockaddr *localAddr,const struct sockaddr *from,void *data,unsigned long len)
 	{
+		if (_forceTcpRelay) {
+			return;
+		}
 		const uint64_t now = OSUtils::now();
 		if ((len >= 16)&&(reinterpret_cast<const InetAddress *>(from)->ipScope() == InetAddress::IP_SCOPE_GLOBAL))
 			_lastDirectReceiveFromGlobal = now;
@@ -3094,7 +3107,7 @@ public:
 					// IP address in ZT_TCP_FALLBACK_AFTER milliseconds. If we do start getting
 					// valid direct traffic we'll stop using it and close the socket after a while.
 					const int64_t now = OSUtils::now();
-					if (((now - _lastDirectReceiveFromGlobal) > ZT_TCP_FALLBACK_AFTER)&&((now - _lastRestart) > ZT_TCP_FALLBACK_AFTER)) {
+					if (_forceTcpRelay || (((now - _lastDirectReceiveFromGlobal) > ZT_TCP_FALLBACK_AFTER)&&((now - _lastRestart) > ZT_TCP_FALLBACK_AFTER))) {
 						if (_tcpFallbackTunnel) {
 							bool flushNow = false;
 							{
@@ -3120,7 +3133,7 @@ public:
 								void *tmpptr = (void *)_tcpFallbackTunnel;
 								phyOnTcpWritable(_tcpFallbackTunnel->sock,&tmpptr);
 							}
-						} else if (((now - _lastSendToGlobalV4) < ZT_TCP_FALLBACK_AFTER)&&((now - _lastSendToGlobalV4) > (ZT_PING_CHECK_INVERVAL / 2))) {
+						} else if (_forceTcpRelay || (((now - _lastSendToGlobalV4) < ZT_TCP_FALLBACK_AFTER)&&((now - _lastSendToGlobalV4) > (ZT_PING_CHECK_INVERVAL / 2)))) {
 							const InetAddress addr(_fallbackRelayAddress);
 							TcpConnection *tc = new TcpConnection();
 							{
@@ -3141,12 +3154,15 @@ public:
 				}
 			}
 		}
+		if (_forceTcpRelay) {
+			// Shortcut here so that we don't emit any UDP packets
+			return 0;
+		}
 #endif // ZT_TCP_FALLBACK_RELAY
 
 		// Even when relaying we still send via UDP. This way if UDP starts
 		// working we can instantly "fail forward" to it and stop using TCP
 		// proxy fallback, which is slow.
-
 		if ((localSocket != -1)&&(localSocket != 0)&&(_binder.isUdpSocketValid((PhySocket *)((uintptr_t)localSocket)))) {
 			if ((ttl)&&(addr->ss_family == AF_INET)) _phy.setIp4UdpTtl((PhySocket *)((uintptr_t)localSocket),ttl);
 			const bool r = _phy.udpSend((PhySocket *)((uintptr_t)localSocket),(const struct sockaddr *)addr,data,len);


### PR DESCRIPTION
This patch allows users to specify the physical layer MTU for individual links
when in multipath mode. For example:

```
{
  "settings":
  {
    "defaultBondingPolicy": "custom-balance-xor",
    "policies":
    {
      "custom-balance-xor":
      {
        "basePolicy": "balance-xor",
        "failoverInterval": 5000,
        "links": {
          "weird_5g_link": { "mtu": 1300 },
          "enp5s0": { "mtu": 1400  }
        }
      }
    }
  }
}
```