### PR TITLE
Fix Possible misuse of comma operator here

### DIFF
--- a/node/Packet.cpp
+++ b/node/Packet.cpp
@@ -605,7 +605,11 @@ _next_match:
 				*token += ML_MASK;
 				matchCode -= ML_MASK;
 				LZ4_write32(op, 0xFFFFFFFF);
-				while (matchCode >= 4*255) op+=4, LZ4_write32(op, 0xFFFFFFFF), matchCode -= 4*255;
+				while (matchCode >= 4*255) {
+					op+=4;
+					LZ4_write32(op, 0xFFFFFFFF);
+					matchCode -= 4*255;
+				}
 				op += matchCode / 255;
 				*op++ = (BYTE)(matchCode % 255);
 			} else


### PR DESCRIPTION
Xcode warns about "Possible misuse of comma operator here". Comma is a sequencing operator in C++ and original code does work, but is highly non-idiomatic.