### PR TITLE
Check for ARM Cryptography Extension support

### DIFF
--- a/node/AES.hpp
+++ b/node/AES.hpp
@@ -24,7 +24,7 @@
 #if !defined(ZT_AES_NO_ACCEL) && defined(ZT_ARCH_X64)
 #define ZT_AES_AESNI 1
 #endif
-#if !defined(ZT_AES_NO_ACCEL) && defined(ZT_ARCH_ARM_HAS_NEON)
+#if !defined(ZT_AES_NO_ACCEL) && defined(ZT_ARCH_ARM_HAS_NEON) && defined(ZT_ARCH_ARM_HAS_CRYPTO)
 #define ZT_AES_NEON 1
 #endif
 

--- a/node/Constants.hpp
+++ b/node/Constants.hpp
@@ -137,6 +137,13 @@
 #endif
 #endif
 
+#ifndef ZT_ARCH_ARM_HAS_CRYPTO
+#if defined(__ARM_FEATURE_CRYPTO)
+// ARM Cryptography Extension
+#define ZT_ARCH_ARM_HAS_CRYPTO
+#endif
+#endif
+
 // Define ZT_NO_TYPE_PUNNING to disable reckless casts on anything other than x86/x64.
 #if (!(defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64) || defined(_M_AMD64) || defined(_M_X64) || defined(i386) || defined(__i386) || defined(__i386__) || defined(__i486__) || defined(__i586__) || defined(__i686__) || defined(_M_IX86) || defined(__X86__) || defined(_X86_) || defined(__I86__) || defined(__INTEL__) || defined(__386)))
 #ifndef ZT_NO_TYPE_PUNNING


### PR DESCRIPTION
ARM Cryptography Extension is optional and not all ARM CPUs support it. For example, the CPU in Raspberry Pi 4 does not support it.

Check for `__ARM_FEATURE_CRYPTO` before attempting to use the optional extension.

`__ARM_FEATURE_CRYPTO` is defined by both clang and gcc when the target has the cryptography extension.

Fixes #1854.