### PR TITLE
Fix setMtu() on Linux. Add error checking

### DIFF
--- a/osdep/LinuxEthernetTap.cpp
+++ b/osdep/LinuxEthernetTap.cpp
@@ -556,7 +556,7 @@ void LinuxEthernetTap::setMtu(unsigned int mtu)
 			strcpy(ifr.ifr_name,_dev.c_str());
 			ifr.ifr_ifru.ifru_mtu = (int)mtu;
 			if (ioctl(sock,SIOCSIFMTU,(void *)&ifr) < 0) {
-				printf("WARNING: ioctl() failed setting up Linux tap device (set MTU)\n");
+				printf("WARNING: ioctl() failed updating existing Linux tap device (set MTU)\n");
 			}
 			close(sock);
 		}

--- a/osdep/LinuxEthernetTap.cpp
+++ b/osdep/LinuxEthernetTap.cpp
@@ -553,8 +553,11 @@ void LinuxEthernetTap::setMtu(unsigned int mtu)
 		if (sock > 0) {
 			struct ifreq ifr;
 			memset(&ifr,0,sizeof(ifr));
+			strcpy(ifr.ifr_name,_dev.c_str());
 			ifr.ifr_ifru.ifru_mtu = (int)mtu;
-			ioctl(sock,SIOCSIFMTU,(void *)&ifr);
+			if (ioctl(sock,SIOCSIFMTU,(void *)&ifr) < 0) {
+				printf("WARNING: ioctl() failed setting up Linux tap device (set MTU)\n");
+			}
 			close(sock);
 		}
 	}


### PR DESCRIPTION
This patch lets us set the MTU on Linux machines from Central.

The problem was that the interface structure was being memset to zero and then used without providing the device name string, since there was no error checking it was failing silently and never getting applied.

This addresses tickets #1554 and #1804 and an issue mentioned by @PatrykW-95 in issue #1590