### PR TITLE
Added docker environment way to join networks

### DIFF
--- a/README.docker.md
+++ b/README.docker.md
@@ -60,6 +60,7 @@ To ensure you have a network available before trying to listen on it. Without pr
 
 You can control a few settings including the identity used and the authtoken used to interact with the control socket (which you can forward and access through `localhost:9993`).
 
+- `ZEROTIER_JOIN_NETWORKS`: additional way to set networks to join.
 - `ZEROTIER_API_SECRET`: replaces the `authtoken.secret` before booting and allows you to manage the control socket's authentication key.
 - `ZEROTIER_IDENTITY_PUBLIC`: the `identity.public` file for zerotier-one. Use `zerotier-idtool` to generate one of these for you.
 - `ZEROTIER_IDENTITY_SECRET`: the `identity.secret` file for zerotier-one. Use `zerotier-idtool` to generate one of these for you.

--- a/entrypoint.sh.release
+++ b/entrypoint.sh.release
@@ -71,12 +71,22 @@ trap killzerotier INT TERM
 log "Configuring networks to join"
 mkdir -p /var/lib/zerotier-one/networks.d
 
-log_params "Joining networks:" $@
+log_params "Joining networks from command line:" $@
 for i in "$@"
 do
   log_detail_params "Configuring join:" "$i"
   touch "/var/lib/zerotier-one/networks.d/${i}.conf"
 done
+
+if [ "x$ZEROTIER_JOIN_NETWORKS" != "x" ]
+then
+  log_params "Joining networks from environment:" $ZEROTIER_JOIN_NETWORKS
+  for i in "$ZEROTIER_JOIN_NETWORKS"
+  do
+    log_detail_params "Configuring join:" "$i"
+    touch "/var/lib/zerotier-one/networks.d/${i}.conf"
+  done
+fi
 
 log "Starting ZeroTier"
 nohup /usr/sbin/zerotier-one &


### PR DESCRIPTION
My idea to allow network join via environment comes has a workarround for https://phabricator.vyos.net/T4014 and Zerotier usage on VyOS (Particularly on VyOS we still need to use devicemap to map networks to a tunX interface, but its now possible with this commit).