### PR TITLE
Turn off autocrlf for rust source

### DIFF
--- a/zeroidc/.gitattributes
+++ b/zeroidc/.gitattributes
@@ -1,0 +1,3 @@
+# disable autocrlf because it doesn't mix well with
+# vendored rust packages
+* text=false


### PR DESCRIPTION
Doesn't appear to play nice well when it comes to git and vendored cargo package hashes