### PR TITLE
Fix #1883

### DIFF
--- a/osdep/WindowsEthernetTap.cpp
+++ b/osdep/WindowsEthernetTap.cpp
@@ -850,12 +850,14 @@ void WindowsEthernetTap::setFriendlyName(const char *dn)
 					NETCON_PROPERTIES *ncp = nullptr;
 					nc->GetProperties(&ncp);
 
-					GUID curId = ncp->guidId;
-					if (curId == _deviceGuid) {
-						wchar_t wtext[255];
-						mbstowcs(wtext, dn, strlen(dn)+1);
-						nc->Rename(wtext);
-						found = true;
+					if (ncp != nullptr) {
+						GUID curId = ncp->guidId;
+						if (curId == _deviceGuid) {
+							wchar_t wtext[255];
+							mbstowcs(wtext, dn, strlen(dn)+1);
+							nc->Rename(wtext);
+							found = true;
+						}
 					}
 					nc->Release();
 				}


### PR DESCRIPTION
Still unknown as to why, but the call to `nc->GetProperties()` can fail when setting a friendly name on the Windows virtual ethernet adapter. Ensure that `ncp` is not null before continuing and accessing the device GUID.