### PR TITLE
[+] add e2k64 arch

### DIFF
--- a/make-linux.mk
+++ b/make-linux.mk
@@ -146,6 +146,9 @@ endif
 ifeq ($(CC_MACH),e2k)
 	ZT_ARCHITECTURE=2
 endif
+ifeq ($(CC_MACH),e2k64)
+	ZT_ARCHITECTURE=2
+endif
 ifeq ($(CC_MACH),i386)
 	ZT_ARCHITECTURE=1
 	ZT_SSO_SUPPORTED=1


### PR DESCRIPTION
Add e2k64 arch.
clang dumpmachine returns e2k64 target with new Linux Elbrus OS and Elbrus processors. 
Compiles and runs fine. Tested with Elbrus Linux 7.1 and Elbrus e2c3 CPU. clang version 9.0.1