### PR TITLE
Increase ZT_MAX_PEER_NETWORK_PATHS to 128

### DIFF
--- a/include/ZeroTierOne.h
+++ b/include/ZeroTierOne.h
@@ -168,7 +168,7 @@ extern "C" {
 /**
  * Maximum number of direct network paths to a given peer
  */
-#define ZT_MAX_PEER_NETWORK_PATHS 64
+#define ZT_MAX_PEER_NETWORK_PATHS 128
 
 /**
  * Maximum number of path configurations that can be set


### PR DESCRIPTION
Too many paths

Historically if ZeroTier received a packet on a path that had the same IP but a different port it would simply overwrite that entry and learn the new path (to a max of `16`). This worked well enough for simple cases. In fact, the vast majority of cases. However if we look at the logs of those early versions you could see ZeroTier constantly learning, forgetting, and re-learning the same paths. Even in this state it wasn't too big of a problem since it didn't prevent communication (the path would be re-learnt for each incoming packet just in time) and didn't eat up much CPU, but it was still an undesirable state.

In response to this I changed how we learn paths and bumped the max allowed paths to `64` and now ZeroTier will accumulate more paths (this isn't the dupe path issue), and it will only overwrite an entry if there are no slots left, even when it overwrites a path it will prioritize based on similarity to the new path. This seems to work a lot better but the side effect is that we end up with huge numbers of paths when people use multiple interfaces with multiple addresses. In most cases this is fine. However we're seeing people reporting high CPU usage when instances of ZeroTier are running into the `64` max cap since people are using multiple interfaces with multiple addresses on both ends. (See: https://discuss.zerotier.com/t/constant-high-cpu-usage-on-raspberry-pi-4/11533/32)

Here are the options as I see it:

1) Ignore reports and let the high CPU bugs persist.

2) Once again bump the max path count to `128` or `whatever`. This doesn't *solve* the issue but does kick the can down the road. Even though a linear search happens for each incoming/outgoing packet I don't think it's a significant performance bottleneck and even if it is, it would only affect a small number of people filling up the array. One additional side effect would be an increased memory footprint that wouldn't be severe but possibly an issue on memory constrained environments like mobile where memory per process is absurdly low.

3) introduce a learning backoff timer but if we aren't learning all the paths possible then there might be missed traffic.

4) Forget paths more quickly

My inclination would be to bump it to `128` and confirm that it doesn't cause too much additional memory usage and possibly tune ZeroTier to forget paths more quickly.

Thoughts?