### PR TITLE
fix binding temporary ipv6 addresses on macos

### DIFF
--- a/osdep/Binder.hpp
+++ b/osdep/Binder.hpp
@@ -42,7 +42,7 @@
 
 #if (defined(__unix__) || defined(__APPLE__)) && !defined(__LINUX__) && !defined(ZT_SDK)
 #include <net/if.h>
-#if ! defined(TARGET_OS_IOS)
+#if defined(TARGET_OS_OSX)
 #include <netinet6/in6_var.h>
 #endif
 #include <sys/ioctl.h>
@@ -333,7 +333,7 @@ class Binder {
 					while (ifa) {
 						if ((ifa->ifa_name) && (ifa->ifa_addr)) {
 							InetAddress ip = *(ifa->ifa_addr);
-#if (defined(__unix__) || defined(__APPLE__)) && !defined(__LINUX__) && !defined(ZT_SDK) && !defined(TARGET_OS_IOS)
+#if (defined(__unix__) || defined(__APPLE__)) && !defined(__LINUX__) && !defined(ZT_SDK) && defined(TARGET_OS_OSX)
 							// Check if the address is an IPv6 Temporary Address, macOS/BSD version
 							if (ifa->ifa_addr->sa_family == AF_INET6) {
 								struct sockaddr_in6* sa6 = (struct sockaddr_in6*)ifa->ifa_addr;
@@ -349,8 +349,8 @@ class Binder {
 
 								// if this is a temporary IPv6 address, skip to the next address
 								if (flags & IN6_IFF_TEMPORARY) {
-									char buf[64];
 #ifdef ZT_TRACE
+									char buf[64];
 									fprintf(stderr, "skip binding to temporary IPv6 address: %s\n", ip.toIpString(buf));
 #endif
 									ifa = ifa->ifa_next;


### PR DESCRIPTION
The check code wasn't running.

I don't know why !defined(TARGET_OS_IOS) would exclude code on desktop macOS. I did a quick search and changed it to defined(TARGET_OS_OSX). Not 100% sure what the most correct solution there is.

You can verify the old and new versions with

`ifconfig | grep temporary`

plus

`zerotier-cli info -j` -> listeningOn