### PR TITLE
Fixing and optimizing issues related to IP address allocation.

### DIFF
--- a/controller/EmbeddedNetworkController.cpp
+++ b/controller/EmbeddedNetworkController.cpp
@@ -1235,6 +1235,7 @@ void EmbeddedNetworkController::_request(
 	const Identity &identity,
 	const Dictionary<ZT_NETWORKCONFIG_METADATA_DICT_CAPACITY> &metaData)
 {
+    std::lock_guard<std::mutex> l(_request_l);
 	char nwids[24];
 	DB::NetworkSummaryInfo ns;
 	json network,member;
@@ -1736,7 +1737,7 @@ void EmbeddedNetworkController::_request(
 
 					if ((ipRangeEnd < ipRangeStart)||(ipRangeStart == 0))
 						continue;
-					uint32_t ipRangeLen = ipRangeEnd - ipRangeStart;
+					uint32_t ipRangeLen = ipRangeEnd - ipRangeStart + 1;
 
 					// Start with the LSB of the member's address
 					uint32_t ipTrialCounter = (uint32_t)(identity.address().toInt() & 0xffffffff);

--- a/controller/EmbeddedNetworkController.hpp
+++ b/controller/EmbeddedNetworkController.hpp
@@ -160,6 +160,8 @@ private:
 
 	RedisConfig *_rc;
 	std::string _ssoRedirectURL;
+
+	std::mutex _request_l;
 };
 
 } // namespace ZeroTier


### PR DESCRIPTION
1. Fix the issue where there is a chance of assigning the same IP when allocating IPs for simultaneous requests.

2. Optimizing the calculation method for converting IP ranges into the actual number of IP addresses.

Bug reproduction method:

Issue 1. Add two or more nodes to the same network group, authorize access, configure routing and IP range, and then enable the automatic IP allocation option. Multiple nodes will be assigned the same IP address.

Issue 2. IP range is set as 10.10.0.1-10.10.0.2, assigned to two nodes. I believe that one node should be assigned 10.10.0.1 and the other node should be assigned 10.10.0.2. However, in reality, only one node can obtain the IP address of 10.10.0.1, and the other node cannot obtain an IP address.

Review needed.

--The above is the translation obtained through translation software

bug复现方法:

问题1. 将2个以上节点加入同一个网络组, 并授权访问, 配置好路由和ip范围, 此时再打开自动分配IP的选项, 多个节点会分配到同一个IP地址.
问题2. ip范围设置为10.10.0.1-10.10.0.2, 分给2个节点, 我认为应该一个分到10.10.0.1, 另一个节点分到10.10.0.2, 但实际上只有一个节点能获得10.10.0.1的ip, 另一个节点获取不到ip