### PR TITLE
Windows ARM64 Support for TapDriver6 (including Signed Driver)

### DIFF
--- a/windows/TapDriver6/tap.h
+++ b/windows/TapDriver6/tap.h
@@ -25,10 +25,11 @@
 #define __TAP_H
 
 #ifndef NDIS_SUPPORT_NDIS6
-#define NDIS_SUPPORT_NDIS6 1
-#define NDIS_SUPPORT_NDIS61 1
-#define NDIS_WDM1 1
-#define NDIS61_MINIPORT 1
+#define NDIS_MINIPORT_DRIVER 1
+#define NDIS_SUPPORT_NDIS6	 1
+#define NDIS_SUPPORT_NDIS630 1
+#define NDIS_WDM1			 1
+#define NDIS630_MINIPORT	 1
 #endif
 
 #include <ntifs.h>

--- a/windows/TapDriver6/zttap300.inf
+++ b/windows/TapDriver6/zttap300.inf
@@ -35,13 +35,18 @@ Provider = "ZeroTier"
 
 [Manufacturer]
 %Provider%=zttap300,NTx86
-;%Provider%=zttap300,NTamd64
+%Provider%=zttap300,NTamd64
+%Provider%=zttap300,NTarm64
 
 [zttap300.NTx86]
 %DeviceDescription% = zttap300.ndi, root\zttap300 ; Root enumerated
 %DeviceDescription% = zttap300.ndi, zttap300      ; Legacy
 
 [zttap300.NTamd64]
+%DeviceDescription% = zttap300.ndi, root\zttap300 ; Root enumerated
+%DeviceDescription% = zttap300.ndi, zttap300      ; Legacy
+
+[zttap300.NTarm64]
 %DeviceDescription% = zttap300.ndi, root\zttap300 ; Root enumerated
 %DeviceDescription% = zttap300.ndi, zttap300      ; Legacy
 


### PR DESCRIPTION
Hi there-
Following up from the work over at https://github.com/zerotier/ZeroTierOne/pull/1837 by @chenxijun - and this also at least in part solves:
https://github.com/zerotier/ZeroTierOne/pull/1147
https://github.com/zerotier/ZeroTierOne/issues/1141
https://github.com/zerotier/ZeroTierOne/issues/1098

Unlike chenxijun I did not go and modify anything other than the driver files. At least in my testing the service and UI both function fine on Windows 10 and 11, on ARM using the inbuilt and default emulation.  Although it would be great if the MSI installer didn't block install on ARM (copy the files, and run `ZeroTier/One/zerotier-one_arm64.exe -I` as an admin)

After build (and driver signing) - I copied the 3 files to `C:\ProgramData\Zerotier\One\tap-windows\arm64` and then manully installed the driver (right click, install on the inf file). 

I did go and get the driver signed by Microsoft for arm (all windows 10/11 versions), since I understand that this can be hard to do - and I had the approvals, keys and methods at hand. You are free to incorporate these as if you wish. Here are the signed files: [zttap300.zip](https://github.com/zerotier/ZeroTierOne/files/11115819/zttap300.zip)

But... that said - I now have a working ZeroTier install on my Surface Pro 9 without going into any test modes:
![image](https://user-images.githubusercontent.com/10895705/228957036-354ac92c-563d-448f-a869-54c0f682debb.png)
![image](https://user-images.githubusercontent.com/10895705/228957077-cf7cd776-f7ab-4b4c-b88a-2eafab186a0a.png)

![image](https://user-images.githubusercontent.com/10895705/228957394-d9bcbf2c-e254-4c0e-af05-78852f7fb125.png)

I hope VERY VERY much that you can integrate this into your released installers soon