### PR TITLE
Fix multiple network join from environment entrypoint.sh.release

### DIFF
--- a/entrypoint.sh.release
+++ b/entrypoint.sh.release
@@ -81,7 +81,7 @@ done
 if [ "x$ZEROTIER_JOIN_NETWORKS" != "x" ]
 then
   log_params "Joining networks from environment:" $ZEROTIER_JOIN_NETWORKS
-  for i in "$ZEROTIER_JOIN_NETWORKS"
+  for i in $ZEROTIER_JOIN_NETWORKS
   do
     log_detail_params "Configuring join:" "$i"
     touch "/var/lib/zerotier-one/networks.d/${i}.conf"


### PR DESCRIPTION
Hello!

This is a bugfix on feature "Join networks from environment" in Docker image. 

I have this patch in production and built the following way

```
podman buildx build -t quay.io/pqatsi/zerotier:latest -t quay.io/pqatsi/zerotier:1.10.6 --build-arg VERSION=1.10.6 -f Dockerfile.release .
```

pushed to https://quay.io/repository/pqatsi/zerotier?tab=tags

May this PR be approved? Also, does Zerotier interest on refactor this image? I did a experimental build at https://github.com/zerotier/ZeroTierOne/issues/1940#issuecomment-1486017714 to test a issue and I see this image is smaller and more enterprise-ready than current ones. I can do some also only improvements on debian-base if its the case too - like avoid multiple-layer hell.

Thanks!