### PR TITLE
Improvements on Dockerfile.release

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,23 +1,22 @@
 # vim: ft=dockerfile
 
-FROM debian:bullseye
+FROM docker.io/library/debian:bullseye-slim
 
 ARG VERSION
 
-RUN apt-get update -qq && apt-get install curl gpg -y
-RUN mkdir -p /usr/share/zerotier && \
-    curl -o /usr/share/zerotier/tmp.asc "https://download.zerotier.com/contact%40zerotier.com.gpg" && \
-    gpg --no-default-keyring --keyring /usr/share/zerotier/zerotier.gpg --import /usr/share/zerotier/tmp.asc && \
-    rm -f /usr/share/zerotier/tmp.asc && \
-    echo "deb [signed-by=/usr/share/zerotier/zerotier.gpg] http://download.zerotier.com/debian/bullseye bullseye main" > /etc/apt/sources.list.d/zerotier.list
-
-RUN apt-get update -qq && apt-get install zerotier-one=${VERSION} curl iproute2 net-tools iputils-ping openssl libssl1.1 -y
-RUN rm -rf /var/lib/zerotier-one
-
 COPY entrypoint.sh.release /entrypoint.sh
-RUN chmod 755 /entrypoint.sh
+
+RUN apt -y update \
+    && apt -y -o APT::Install-Suggests=0 -o APT::Install-Recommends=0 install ca-certificates curl gpg \
+    && curl -sSL "https://download.zerotier.com/contact%40zerotier.com.gpg" | gpg --dearmor > /etc/apt/trusted.gpg.d/zerotier.gpg \
+    && echo "deb http://download.zerotier.com/debian/bullseye bullseye main" > /etc/apt/sources.list.d/zerotier.list \
+    && apt -y update \
+    && apt -y install zerotier-one=${VERSION} \
+    && apt -y -o APT::Install-Suggests=0 -o APT::Install-Recommends=0 install iproute2 net-tools iputils-ping \
+    && apt -y purge ca-certificates curl gpg gpgconf \
+    && chmod 755 /entrypoint.sh \
+    && rm -rf /etc/apt/trusted.gpg.d/zerotier.gpg /var/lib/zerotier-one /var/lib/apt/lists/* /var/cache/apt/*
 
 HEALTHCHECK --interval=1s CMD bash /healthcheck.sh
 
-CMD []
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,21 +1,24 @@
 # vim: ft=dockerfile
+FROM docker.io/library/debian:bullseye-slim as gpg
+
+RUN apt -y update \
+    && apt -y -o APT::Install-Suggests=0 -o APT::Install-Recommends=0 install ca-certificates gpg gpg-agent curl \
+    && curl -sSL https://download.zerotier.com/contact%40zerotier.com.gpg -o /zerotier.asc \
+    && gpg --no-default-keyring --keyring /tmp/zerotier.gpg --import /zerotier.asc
 
 FROM docker.io/library/debian:bullseye-slim
 
 ARG VERSION
 
 COPY entrypoint.sh.release /entrypoint.sh
+COPY --from=gpg /tmp/zerotier.gpg /etc/apt/keyrings/zerotier.gpg
 
-RUN apt -y update \
-    && apt -y -o APT::Install-Suggests=0 -o APT::Install-Recommends=0 install ca-certificates curl gpg \
-    && curl -sSL "https://download.zerotier.com/contact%40zerotier.com.gpg" | gpg --dearmor > /etc/apt/trusted.gpg.d/zerotier.gpg \
-    && echo "deb http://download.zerotier.com/debian/bullseye bullseye main" > /etc/apt/sources.list.d/zerotier.list \
+RUN echo "deb [signed-by=/etc/apt/keyrings/zerotier.gpg] http://download.zerotier.com/debian/bullseye bullseye main" > /etc/apt/sources.list.d/zerotier.list \
     && apt -y update \
-    && apt -y install zerotier-one=${VERSION} \
-    && apt -y -o APT::Install-Suggests=0 -o APT::Install-Recommends=0 install iproute2 net-tools iputils-ping \
-    && apt -y purge ca-certificates curl gpg gpgconf \
+    && apt -y install -o APT::Install-Suggests=0 -o APT::Install-Recommends=0 zerotier-one=${VERSION} iproute2 net-tools iputils-ping \
+    && apt -y purge ca-certificates gpg gpgconf \
     && chmod 755 /entrypoint.sh \
-    && rm -rf /etc/apt/trusted.gpg.d/zerotier.gpg /var/lib/zerotier-one /var/lib/apt/lists/* /var/cache/apt/*
+    && rm -rf /etc/apt/trusted.gpg.d/zerotier.gpg /var/lib/zerotier-one /var/lib/apt/lists/* /var/cache/apt/* /var/log/apt/* 
 
 HEALTHCHECK --interval=1s CMD bash /healthcheck.sh
 


### PR DESCRIPTION
Hello! 

As discussed in https://github.com/zerotier/ZeroTierOne/pull/1961 - i'm proposing the following improvements on Docker image of Zerotier:

* Change image to docker.io/library/debian:bullseye-slim (Slim variant with complete path to allow easier fetch for podman/oci-like container systems)
* Rebuilt instalation procedure to avoid unnecessary packages and trash like caches and packages that aren't used.
* Removed unecessary layers (Since ALL layers are pulled when user fetches the image) to decrease docker image size.

The image built at point of this commit is available on quay.io/pqatsi/zerotier:1.10.6 and was tested as following evidence:

```
leonardo@stargate-sg1:~$ sudo podman image ls
WARN[0000] Switching default driver from overlay2 to the equivalent overlay driver 
REPOSITORY               TAG         IMAGE ID      CREATED        SIZE
quay.io/pqatsi/zerotier  1.10.6      4e0ffa65aca0  2 minutes ago  107 MB
leonardo@stargate-sg1:~$ sudo podman ps
WARN[0000] Switching default driver from overlay2 to the equivalent overlay driver 
CONTAINER ID  IMAGE                           COMMAND     CREATED         STATUS             PORTS       NAMES
2d922526c544  quay.io/pqatsi/zerotier:1.10.6              17 seconds ago  Up 17 seconds ago              zerotier
leonardo@stargate-sg1:~$ show log container zerotier 
WARN[0000] Switching default driver from overlay2 to the equivalent overlay driver 
^M=> Configuring networks to join
^M=> Joining networks from command line: []
^M=> Joining networks from environment: [<NETWORK1> <NETWORK2>]
^M===> Configuring join: [<NETWORK1>]
^M===> Configuring join: [<NETWORK2>]
^M=> Starting ZeroTier
nohup: appending output to 'nohup.out'
^M===> ZeroTier hasn't started, waiting a second
^M=> Writing healthcheck for networks: []
^M=> zerotier-cli info: [200 info <CLIENT_ID> 1.10.6 OFFLINE]
^M=> Sleeping infinitely
leonardo@stargate-sg1:~$ sudo podman exec -it zerotier zerotier-cli info
WARN[0000] Switching default driver from overlay2 to the equivalent overlay driver 
200 info <CLIENT_ID> 1.10.6 ONLINE
leonardo@stargate-sg1:~$ 
```

And all networks are working well. 

It's possible to review and approve this PR?