### PR TITLE
Fix: warning: mutex '_aqm_m' is not held on every path through here […

### DIFF
--- a/node/Switch.cpp
+++ b/node/Switch.cpp
@@ -642,6 +642,7 @@ void Switch::aqm_enqueue(void *tPtr, const SharedPtr<Network> &network, Packet &
 		}
 	}
 	if (!selectedQueue) {
+		_aqm_m.unlock();
 		return;
 	}
 


### PR DESCRIPTION
…-Wthread-safety-analysis]