### PR TITLE
Metrics consolidation

### DIFF
--- a/make-linux.mk
+++ b/make-linux.mk
@@ -311,7 +311,7 @@ endif
 ifeq ($(ZT_CONTROLLER),1)
 	override CXXFLAGS+=-Wall -Wno-deprecated -std=c++17 -pthread $(INCLUDES) -DNDEBUG $(DEFS)
 	override LDLIBS+=-Lext/libpqxx-7.7.3/install/ubuntu22.04/lib -lpqxx -lpq ext/hiredis-1.0.2/lib/ubuntu22.04/libhiredis.a ext/redis-plus-plus-1.3.3/install/ubuntu22.04/lib/libredis++.a -lssl -lcrypto
-	override DEFS+=-DZT_CONTROLLER_USE_LIBPQ
+	override DEFS+=-DZT_CONTROLLER_USE_LIBPQ -DZT_NO_PEER_METRICS
 	override INCLUDES+=-I/usr/include/postgresql -Iext/libpqxx-7.7.3/install/ubuntu22.04/include -Iext/hiredis-1.0.2/include/ -Iext/redis-plus-plus-1.3.3/install/ubuntu22.04/include/sw/
 endif
 

--- a/node/Metrics.cpp
+++ b/node/Metrics.cpp
@@ -157,18 +157,16 @@ namespace ZeroTier {
         { packet_errors.Add({{"error_type", "internal_server_error"}, {"direction", "tx"}}) };
 
         // Data Sent/Received Metrics
-        prometheus::simpleapi::counter_family_t udp
-        { "zt_udp_data", "number of bytes ZeroTier has transmitted or received via UDP" };
+        prometheus::simpleapi::counter_family_t data
+        { "zt_data", "number of bytes ZeroTier has transmitted or received via UDP" };
         prometheus::simpleapi::counter_metric_t udp_recv
-        { udp.Add({{"direction","rx"}}) };
+        { data.Add({{"protocol","udp"},{"direction","rx"}}) };
         prometheus::simpleapi::counter_metric_t udp_send
-        { udp.Add({{"direction","tx"}}) };
-        prometheus::simpleapi::counter_family_t tcp
-        { "zt_tcp_data", "number of bytes ZeroTier has transmitted or received via TCP" };
+        { data.Add({{"protocol","udp"},{"direction","tx"}}) };
         prometheus::simpleapi::counter_metric_t tcp_send
-        { tcp.Add({{"direction", "tx"}}) };
+        { data.Add({{"protocol","tcp"},{"direction", "tx"}}) };
         prometheus::simpleapi::counter_metric_t tcp_recv
-        { tcp.Add({{"direction", "rx"}}) };
+        { data.Add({{"protocol","tcp"},{"direction", "rx"}}) };
 
         // Network Metrics
         prometheus::simpleapi::gauge_metric_t network_num_joined

--- a/node/Metrics.cpp
+++ b/node/Metrics.cpp
@@ -172,12 +172,10 @@ namespace ZeroTier {
         prometheus::simpleapi::gauge_metric_t network_num_joined
         { "zt_num_networks", "number of networks this instance is joined to" };
         prometheus::simpleapi::gauge_family_t network_num_multicast_groups
-        { "zt_network_multcast_groups_subscribed", "number of multicast groups networks are subscribed to" };
-        prometheus::simpleapi::counter_family_t network_incoming_packets
-        { "zt_network_incoming_packets", "number of incoming packets per network" };
-        prometheus::simpleapi::counter_family_t network_outgoing_packets
-        { "zt_network_outgoing_packets", "number of outgoing packets per network" };
-
+        { "zt_network_multicast_groups_subscribed", "number of multicast groups networks are subscribed to" };
+        prometheus::simpleapi::counter_family_t network_packets
+        { "zt_network_packets", "number of incoming/outgoing packets per network" };
+        
         // PeerMetrics
         prometheus::CustomFamily<prometheus::Histogram<uint64_t>> &peer_latency = 
         prometheus::Builder<prometheus::Histogram<uint64_t>>()

--- a/node/Metrics.cpp
+++ b/node/Metrics.cpp
@@ -25,7 +25,7 @@ namespace ZeroTier {
     namespace Metrics {
         // Packet Type Counts
         prometheus::simpleapi::counter_family_t packets
-        { "zt_packet_incoming", "incoming packet type counts"};
+        { "zt_packet", "incoming packet type counts"};
 
         // Incoming packets
         prometheus::simpleapi::counter_metric_t pkt_nop_in
@@ -157,14 +157,18 @@ namespace ZeroTier {
         { packet_errors.Add({{"error_type", "internal_server_error"}, {"direction", "tx"}}) };
 
         // Data Sent/Received Metrics
-        prometheus::simpleapi::counter_metric_t udp_send
-        { "zt_udp_data_sent", "number of bytes ZeroTier has sent via UDP" };
+        prometheus::simpleapi::counter_family_t udp
+        { "zt_udp_data", "number of bytes ZeroTier has transmitted or received via UDP" };
         prometheus::simpleapi::counter_metric_t udp_recv
-        { "zt_udp_data_recv", "number of bytes ZeroTier has received via UDP" };
+        { udp.Add({{"direction","rx"}}) };
+        prometheus::simpleapi::counter_metric_t udp_send
+        { udp.Add({{"direction","tx"}}) };
+        prometheus::simpleapi::counter_family_t tcp
+        { "zt_tcp_data", "number of bytes ZeroTier has transmitted or received via TCP" };
         prometheus::simpleapi::counter_metric_t tcp_send
-        { "zt_tcp_data_sent", "number of bytes ZeroTier has sent via TCP" };
+        { tcp.Add({{"direction", "tx"}}) };
         prometheus::simpleapi::counter_metric_t tcp_recv
-        { "zt_tcp_data_recv", "number of bytes ZeroTier has received via TCP" };
+        { tcp.Add({{"direction", "rx"}}) };
 
         // Network Metrics
         prometheus::simpleapi::gauge_metric_t network_num_joined
@@ -185,10 +189,8 @@ namespace ZeroTier {
     
         prometheus::simpleapi::gauge_family_t peer_path_count
         { "zt_peer_path_count", "number of paths to peer" };
-        prometheus::simpleapi::counter_family_t peer_incoming_packets
-        { "zt_peer_incoming_packets", "number of incoming packets from a peer" };
-        prometheus::simpleapi::counter_family_t peer_outgoing_packets
-        { "zt_peer_outgoing_packets", "number of outgoing packets to a peer" };
+        prometheus::simpleapi::counter_family_t peer_packets
+        { "zt_peer_packets", "number of incoming packets from a peer" };
         prometheus::simpleapi::counter_family_t peer_packet_errors
         { "zt_peer_packet_errors" , "number of incoming packet errors from a peer" };
 

--- a/node/Metrics.cpp
+++ b/node/Metrics.cpp
@@ -118,7 +118,7 @@ namespace ZeroTier {
 
         // Packet Error Counts
         prometheus::simpleapi::counter_family_t packet_errors
-        { "zt_packet_incoming_error", "incoming packet errors"};
+        { "zt_packet_error", "incoming packet errors"};
 
         // Incoming Error Counts
         prometheus::simpleapi::counter_metric_t pkt_error_obj_not_found_in

--- a/node/Metrics.cpp
+++ b/node/Metrics.cpp
@@ -176,6 +176,7 @@ namespace ZeroTier {
         prometheus::simpleapi::counter_family_t network_packets
         { "zt_network_packets", "number of incoming/outgoing packets per network" };
         
+#ifndef ZT_NO_PEER_METRICS
         // PeerMetrics
         prometheus::CustomFamily<prometheus::Histogram<uint64_t>> &peer_latency = 
         prometheus::Builder<prometheus::Histogram<uint64_t>>()
@@ -189,6 +190,7 @@ namespace ZeroTier {
         { "zt_peer_packets", "number of packets to/from a peer" };
         prometheus::simpleapi::counter_family_t peer_packet_errors
         { "zt_peer_packet_errors" , "number of incoming packet errors from a peer" };
+#endif
 
         // General Controller Metrics
         prometheus::simpleapi::gauge_metric_t   network_count

--- a/node/Metrics.cpp
+++ b/node/Metrics.cpp
@@ -158,7 +158,7 @@ namespace ZeroTier {
 
         // Data Sent/Received Metrics
         prometheus::simpleapi::counter_family_t data
-        { "zt_data", "number of bytes ZeroTier has transmitted or received via UDP" };
+        { "zt_data", "number of bytes ZeroTier has transmitted or received" };
         prometheus::simpleapi::counter_metric_t udp_recv
         { data.Add({{"protocol","udp"},{"direction","rx"}}) };
         prometheus::simpleapi::counter_metric_t udp_send

--- a/node/Metrics.cpp
+++ b/node/Metrics.cpp
@@ -188,7 +188,7 @@ namespace ZeroTier {
         prometheus::simpleapi::gauge_family_t peer_path_count
         { "zt_peer_path_count", "number of paths to peer" };
         prometheus::simpleapi::counter_family_t peer_packets
-        { "zt_peer_packets", "number of incoming packets from a peer" };
+        { "zt_peer_packets", "number of packets to/from a peer" };
         prometheus::simpleapi::counter_family_t peer_packet_errors
         { "zt_peer_packet_errors" , "number of incoming packet errors from a peer" };
 

--- a/node/Metrics.hpp
+++ b/node/Metrics.hpp
@@ -107,11 +107,13 @@ namespace ZeroTier {
         extern prometheus::simpleapi::gauge_family_t   network_num_multicast_groups;
         extern prometheus::simpleapi::counter_family_t network_packets;
 
+#ifndef ZT_NO_PEER_METRICS
         // Peer Metrics
         extern prometheus::CustomFamily<prometheus::Histogram<uint64_t>> &peer_latency;
         extern prometheus::simpleapi::gauge_family_t   peer_path_count;
         extern prometheus::simpleapi::counter_family_t peer_packets;
         extern prometheus::simpleapi::counter_family_t peer_packet_errors;
+#endif
 
         // General Controller Metrics
         extern prometheus::simpleapi::gauge_metric_t   network_count;

--- a/node/Metrics.hpp
+++ b/node/Metrics.hpp
@@ -96,22 +96,23 @@ namespace ZeroTier {
         extern prometheus::simpleapi::counter_metric_t pkt_error_internal_server_error_out;
 
         // Data Sent/Received Metrics
+        extern prometheus::simpleapi::counter_family_t udp;
         extern prometheus::simpleapi::counter_metric_t udp_send;
         extern prometheus::simpleapi::counter_metric_t udp_recv;
+        extern prometheus::simpleapi::counter_family_t tcp;
         extern prometheus::simpleapi::counter_metric_t tcp_send;
         extern prometheus::simpleapi::counter_metric_t tcp_recv;
 
         // Network Metrics
-        extern prometheus::simpleapi::gauge_metric_t network_num_joined;
-        extern prometheus::simpleapi::gauge_family_t network_num_multicast_groups;
+        extern prometheus::simpleapi::gauge_metric_t   network_num_joined;
+        extern prometheus::simpleapi::gauge_family_t   network_num_multicast_groups;
         extern prometheus::simpleapi::counter_family_t network_incoming_packets;
         extern prometheus::simpleapi::counter_family_t network_outgoing_packets;
 
         // Peer Metrics
         extern prometheus::CustomFamily<prometheus::Histogram<uint64_t>> &peer_latency;
-        extern prometheus::simpleapi::gauge_family_t peer_path_count;
-        extern prometheus::simpleapi::counter_family_t peer_incoming_packets;
-        extern prometheus::simpleapi::counter_family_t peer_outgoing_packets;
+        extern prometheus::simpleapi::gauge_family_t   peer_path_count;
+        extern prometheus::simpleapi::counter_family_t peer_packets;
         extern prometheus::simpleapi::counter_family_t peer_packet_errors;
 
         // General Controller Metrics

--- a/node/Metrics.hpp
+++ b/node/Metrics.hpp
@@ -96,10 +96,9 @@ namespace ZeroTier {
         extern prometheus::simpleapi::counter_metric_t pkt_error_internal_server_error_out;
 
         // Data Sent/Received Metrics
-        extern prometheus::simpleapi::counter_family_t udp;
+        extern prometheus::simpleapi::counter_family_t data;
         extern prometheus::simpleapi::counter_metric_t udp_send;
         extern prometheus::simpleapi::counter_metric_t udp_recv;
-        extern prometheus::simpleapi::counter_family_t tcp;
         extern prometheus::simpleapi::counter_metric_t tcp_send;
         extern prometheus::simpleapi::counter_metric_t tcp_recv;
 

--- a/node/Metrics.hpp
+++ b/node/Metrics.hpp
@@ -105,8 +105,7 @@ namespace ZeroTier {
         // Network Metrics
         extern prometheus::simpleapi::gauge_metric_t   network_num_joined;
         extern prometheus::simpleapi::gauge_family_t   network_num_multicast_groups;
-        extern prometheus::simpleapi::counter_family_t network_incoming_packets;
-        extern prometheus::simpleapi::counter_family_t network_outgoing_packets;
+        extern prometheus::simpleapi::counter_family_t network_packets;
 
         // Peer Metrics
         extern prometheus::CustomFamily<prometheus::Histogram<uint64_t>> &peer_latency;

--- a/node/Network.cpp
+++ b/node/Network.cpp
@@ -569,10 +569,10 @@ Network::Network(const RuntimeEnvironment *renv,void *tPtr,uint64_t nwid,void *u
 	_netconfFailure(NETCONF_FAILURE_NONE),
 	_portError(0),
 	_num_multicast_groups{Metrics::network_num_multicast_groups.Add({{"network_id", _nwidStr}})},
-	_incoming_packets_accpeted{Metrics::network_incoming_packets.Add({{"network_id", _nwidStr},{"accepted","yes"}})},
-	_incoming_packets_dropped{Metrics::network_incoming_packets.Add({{"network_id", _nwidStr},{"accepted","no"}})},
-	_outgoing_packets_accepted{Metrics::network_outgoing_packets.Add({{"network_id", _nwidStr},{"accepted","yes"}})},
-	_outgoing_packets_dropped{Metrics::network_outgoing_packets.Add({{"network_id", _nwidStr},{"accepted","no"}})}
+	_incoming_packets_accepted{Metrics::network_packets.Add({{"direction","rx"},{"network_id", _nwidStr},{"accepted","yes"}})},
+	_incoming_packets_dropped{Metrics::network_packets.Add({{"direction","rx"},{"network_id", _nwidStr},{"accepted","no"}})},
+	_outgoing_packets_accepted{Metrics::network_packets.Add({{"direction","tx"},{"network_id", _nwidStr},{"accepted","yes"}})},
+	_outgoing_packets_dropped{Metrics::network_packets.Add({{"direction","tx"},{"network_id", _nwidStr},{"accepted","no"}})}
 {
 	for(int i=0;i<ZT_NETWORK_MAX_INCOMING_UPDATES;++i) {
 		_incomingConfigChunks[i].ts = 0;
@@ -837,7 +837,7 @@ int Network::filterIncomingPacket(
 	}
 
 	if (accept) {
-		_incoming_packets_accpeted++;
+		_incoming_packets_accepted++;
 		if (cc) {
 			Packet outp(cc,RR->identity.address(),Packet::VERB_EXT_FRAME);
 			outp.append(_id);

--- a/node/Network.hpp
+++ b/node/Network.hpp
@@ -483,7 +483,7 @@ private:
 	AtomicCounter __refCount;
 
 	prometheus::simpleapi::gauge_metric_t _num_multicast_groups;
-	prometheus::simpleapi::counter_metric_t _incoming_packets_accpeted;
+	prometheus::simpleapi::counter_metric_t _incoming_packets_accepted;
 	prometheus::simpleapi::counter_metric_t _incoming_packets_dropped;
 	prometheus::simpleapi::counter_metric_t _outgoing_packets_accepted;
 	prometheus::simpleapi::counter_metric_t _outgoing_packets_dropped;

--- a/node/Peer.cpp
+++ b/node/Peer.cpp
@@ -54,8 +54,8 @@ Peer::Peer(const RuntimeEnvironment *renv,const Identity &myIdentity,const Ident
 	_peer_latency{Metrics::peer_latency.Add({{"node_id", OSUtils::nodeIDStr(peerIdentity.address().toInt())}}, std::vector<uint64_t>{1,3,6,10,30,60,100,300,600,1000})},
 	_alive_path_count{Metrics::peer_path_count.Add({{"node_id", OSUtils::nodeIDStr(peerIdentity.address().toInt())},{"status","alive"}})},
 	_dead_path_count{Metrics::peer_path_count.Add({{"node_id", OSUtils::nodeIDStr(peerIdentity.address().toInt())},{"status","dead"}})},
-	_incoming_packet{Metrics::peer_incoming_packets.Add({{"node_id", OSUtils::nodeIDStr(peerIdentity.address().toInt())}})},
-	_outgoing_packet{Metrics::peer_outgoing_packets.Add({{"node_id", OSUtils::nodeIDStr(peerIdentity.address().toInt())}})},
+	_incoming_packet{Metrics::peer_packets.Add({{"direction", "rx"},{"node_id", OSUtils::nodeIDStr(peerIdentity.address().toInt())}})},
+	_outgoing_packet{Metrics::peer_packets.Add({{"direction", "tx"},{"node_id", OSUtils::nodeIDStr(peerIdentity.address().toInt())}})},
 	_packet_errors{Metrics::peer_packet_errors.Add({{"node_id", OSUtils::nodeIDStr(peerIdentity.address().toInt())}})}
 {
 	if (!myIdentity.agree(peerIdentity,_key)) {

--- a/node/Peer.hpp
+++ b/node/Peer.hpp
@@ -599,12 +599,14 @@ private:
 
 	SharedPtr<Bond> _bond;
 
+#ifndef ZT_NO_PEER_METRICS
 	prometheus::Histogram<uint64_t> &_peer_latency;
 	prometheus::simpleapi::gauge_metric_t _alive_path_count;
 	prometheus::simpleapi::gauge_metric_t _dead_path_count;
 	prometheus::simpleapi::counter_metric_t _incoming_packet;
 	prometheus::simpleapi::counter_metric_t _outgoing_packet;
 	prometheus::simpleapi::counter_metric_t _packet_errors;
+#endif
 };
 
 } // namespace ZeroTier


### PR DESCRIPTION
* Rename zt_packet_incoming to zt_packet. It was misnamed as it already counting both rx and tx packets
* Rename zt_incoming_packet_error to zt_packet_error. It was also misnamed and counting both rx and tx packets
* Consolidate zt_data_tcp_* and zt_data_udp_* into zt_data with tcp/udp and rx/tx labels
* Consolidate zt_peer_packets_incoming and zt_peer_packets_outgoing into zt_peer_packets with tx/rx labels
* Fix label descriptions to reflect the other changes
