### PR TITLE
Don't re-apply routes on BSD

### DIFF
--- a/osdep/ManagedRoute.cpp
+++ b/osdep/ManagedRoute.cpp
@@ -509,13 +509,13 @@ bool ManagedRoute::sync()
 		}
 	}
 
-	//if (!_applied.count(leftt)) {
+	if (leftt && !_applied.count(leftt)) {
 		_applied[leftt] = !_via;
 		//_routeCmd("delete",leftt,_via,(const char *)0,(_via) ? (const char *)0 : _device);
 		_routeCmd("add",leftt,_via,(const char *)0,(_via) ? (const char *)0 : _device);
 		//_routeCmd("change",leftt,_via,(const char *)0,(_via) ? (const char *)0 : _device);
-	//}
-	if (rightt) {
+	}
+	if (rightt && !_applied.count(rightt)) {
 		_applied[rightt] = !_via;
 		//_routeCmd("delete",rightt,_via,(const char *)0,(_via) ? (const char *)0 : _device);
 		_routeCmd("add",rightt,_via,(const char *)0,(_via) ? (const char *)0 : _device);


### PR DESCRIPTION
See issue #1986


We commented out the _applied check in but also changed other stuff in that commit and around that time.
https://github.com/zerotier/ZeroTierOne/commit/594853e2512dfa127e7bf96e7528fbadca61a12d

If anyone with a mac can run this for a while that'd be appreciated. It's based off dev as of a few minutes ago. 