### PR TITLE
Controller Metrics & Network Config Request Fix

### DIFF
--- a/controller/EmbeddedNetworkController.hpp
+++ b/controller/EmbeddedNetworkController.hpp
@@ -81,6 +81,7 @@ public:
 private:
 	void _request(uint64_t nwid,const InetAddress &fromAddr,uint64_t requestPacketId,const Identity &identity,const Dictionary<ZT_NETWORKCONFIG_METADATA_DICT_CAPACITY> &metaData);
 	void _startThreads();
+	void _ssoExpiryThread();
 
 	std::string networkUpdateFromPostData(uint64_t networkID, const std::string &body);
 
@@ -137,6 +138,9 @@ private:
 
 	std::vector<std::thread> _threads;
 	std::mutex _threads_l;
+
+	bool _ssoExpiryRunning;
+	std::thread _ssoExpiry;
 
 	std::unordered_map< _MemberStatusKey,_MemberStatus,_MemberStatusHash > _memberStatus;
 	std::mutex _memberStatus_l;

--- a/node/Metrics.cpp
+++ b/node/Metrics.cpp
@@ -206,6 +206,15 @@ namespace ZeroTier {
         prometheus::simpleapi::counter_metric_t member_deauths
         {"controller_member_deauth_count", "number of network member deauths"};
 
+        prometheus::simpleapi::gauge_metric_t network_config_request_queue_size
+        { "controller_network_config_request_queue", "number of entries in the request queue for network configurations" };
+        
+        prometheus::simpleapi::counter_metric_t sso_expiration_checks
+        { "controller_sso_expiration_checks", "number of sso expiration checks done" };
+
+        prometheus::simpleapi::counter_metric_t sso_member_deauth
+        { "controller_sso_timeouts", "number of sso timeouts" };
+
 #ifdef ZT_CONTROLLER_USE_LIBPQ
         // Central Controller Metrics
         prometheus::simpleapi::counter_metric_t pgsql_mem_notification

--- a/node/Metrics.hpp
+++ b/node/Metrics.hpp
@@ -123,6 +123,10 @@ namespace ZeroTier {
         extern prometheus::simpleapi::counter_metric_t member_auths;
         extern prometheus::simpleapi::counter_metric_t member_deauths;
 
+        extern prometheus::simpleapi::gauge_metric_t network_config_request_queue_size;
+        extern prometheus::simpleapi::counter_metric_t sso_expiration_checks;
+        extern prometheus::simpleapi::counter_metric_t sso_member_deauth;
+
 #ifdef ZT_CONTROLLER_USE_LIBPQ
         // Central Controller Metrics
         extern prometheus::simpleapi::counter_metric_t pgsql_mem_notification;
@@ -131,6 +135,8 @@ namespace ZeroTier {
         extern prometheus::simpleapi::counter_metric_t redis_mem_notification;
         extern prometheus::simpleapi::counter_metric_t redis_net_notification;
         extern prometheus::simpleapi::counter_metric_t redis_node_checkin;
+
+        
 
         // Central DB Pool Metrics
         extern prometheus::simpleapi::counter_metric_t conn_counter;

--- a/osdep/BlockingQueue.hpp
+++ b/osdep/BlockingQueue.hpp
@@ -116,6 +116,11 @@ public:
 		return OK;
 	}
 
+	inline size_t size() const {
+		std::unique_lock<std::mutex> lock(m);
+		return q.size();
+	}
+
 private:
 	std::queue<T> q;
 	mutable std::mutex m;


### PR DESCRIPTION
* get network & member info along with call to _request
* Only run SSO expiration checks if SSO is enabled on the network
* undefined behavior fix when postfix-incrementing an iterator passed to std::set::erase