### PR TITLE
Reduce latency spikes. 

### DIFF
--- a/osdep/BSDEthernetTap.hpp
+++ b/osdep/BSDEthernetTap.hpp
@@ -71,6 +71,8 @@ private:
 	int _fd;
 	int _shutdownSignalPipe[2];
 	volatile bool _enabled;
+	mutable std::vector<InetAddress> _ifaddrs;
+	mutable uint64_t _lastIfAddrsUpdate;
 };
 
 } // namespace ZeroTier

--- a/osdep/EthernetTap.hpp
+++ b/osdep/EthernetTap.hpp
@@ -23,6 +23,8 @@
 #include <memory>
 #include <vector>
 
+#define GETIFADDRS_CACHE_TIME 1000
+
 namespace ZeroTier {
 
 class EthernetTap

--- a/osdep/LinuxEthernetTap.hpp
+++ b/osdep/LinuxEthernetTap.hpp
@@ -57,6 +57,9 @@ public:
 	virtual void setMtu(unsigned int mtu);
 	virtual void setDns(const char *domain, const std::vector<InetAddress> &servers) {}
 
+
+
+
 private:
 	void (*_handler)(void *,void *,uint64_t,const MAC &,const MAC &,unsigned int,unsigned int,const void *,unsigned int);
 	void *_arg;
@@ -71,6 +74,8 @@ private:
 	std::atomic_bool _enabled;
 	std::atomic_bool _run;
 	std::thread _tapReaderThread;
+	mutable std::vector<InetAddress> _ifaddrs;
+	mutable uint64_t _lastIfAddrsUpdate;
 };
 
 } // namespace ZeroTier

--- a/osdep/MacEthernetTap.cpp
+++ b/osdep/MacEthernetTap.cpp
@@ -90,7 +90,8 @@ MacEthernetTap::MacEthernetTap(
 	_agentStdout2(-1),
 	_agentStderr2(-1),
 	_agentPid(-1),
-	_enabled(true)
+	_enabled(true),
+	_lastIfAddrsUpdate(0)
 {
 	char ethaddr[64],mtustr[16],devnostr[16],devstr[16],metricstr[16];
 	OSUtils::ztsnprintf(ethaddr,sizeof(ethaddr),"%.2x:%.2x:%.2x:%.2x:%.2x:%.2x",(int)mac[0],(int)mac[1],(int)mac[2],(int)mac[3],(int)mac[4],(int)mac[5]);
@@ -341,8 +342,16 @@ bool MacEthernetTap::removeIp(const InetAddress &ip)
 
 std::vector<InetAddress> MacEthernetTap::ips() const
 {
+	uint64_t now = OSUtils::now();
+
+	if ((now - _lastIfAddrsUpdate) <= GETIFADDRS_CACHE_TIME) {
+		return _ifaddrs;
+	}
+	_lastIfAddrsUpdate = now;
+
 	struct ifaddrs *ifa = (struct ifaddrs *)0;
 	std::vector<InetAddress> r;
+
 	if (!getifaddrs(&ifa)) {
 		struct ifaddrs *p = ifa;
 		while (p) {
@@ -368,6 +377,9 @@ std::vector<InetAddress> MacEthernetTap::ips() const
 	}
 	std::sort(r.begin(),r.end());
 	r.erase(std::unique(r.begin(),r.end()),r.end());
+
+	_ifaddrs = r;
+
 	return r;
 }
 

--- a/osdep/MacEthernetTap.hpp
+++ b/osdep/MacEthernetTap.hpp
@@ -77,6 +77,9 @@ private:
 	int _agentStdin,_agentStdout,_agentStderr,_agentStdin2,_agentStdout2,_agentStderr2;
 	long _agentPid;
 	volatile bool _enabled;
+	mutable std::vector<InetAddress> _ifaddrs;
+	mutable uint64_t _lastIfAddrsUpdate;
+
 };
 
 } // namespace ZeroTier

--- a/osdep/WindowsEthernetTap.cpp
+++ b/osdep/WindowsEthernetTap.cpp
@@ -467,7 +467,8 @@ WindowsEthernetTap::WindowsEthernetTap(
 	_pathToHelpers(hp),
 	_run(true),
 	_initialized(false),
-	_enabled(true)
+	_enabled(true),
+	_lastIfAddrsUpdate(0)
 {
 	char subkeyName[1024];
 	char subkeyClass[1024];
@@ -749,6 +750,14 @@ std::vector<InetAddress> WindowsEthernetTap::ips() const
 	if (!_initialized)
 		return addrs;
 
+	uint64_t now = OSUtils::now();
+
+	if ((now - _lastIfAddrsUpdate) <= GETIFADDRS_CACHE_TIME) {
+		return _ifaddrs;
+	}
+
+	_lastIfAddrsUpdate = now;
+
 	try {
 		MIB_UNICASTIPADDRESS_TABLE *ipt = (MIB_UNICASTIPADDRESS_TABLE *)0;
 		if (GetUnicastIpAddressTable(AF_UNSPEC,&ipt) == NO_ERROR) {
@@ -776,6 +785,8 @@ std::vector<InetAddress> WindowsEthernetTap::ips() const
 
 	std::sort(addrs.begin(),addrs.end());
 	addrs.erase(std::unique(addrs.begin(),addrs.end()),addrs.end());
+
+	_ifaddrs = addrs;
 
 	return addrs;
 }

--- a/osdep/WindowsEthernetTap.hpp
+++ b/osdep/WindowsEthernetTap.hpp
@@ -152,6 +152,9 @@ private:
 	volatile bool _run;
 	volatile bool _initialized;
 	volatile bool _enabled;
+
+	mutable std::vector<InetAddress> _ifaddrs;
+	mutable uint64_t _lastIfAddrsUpdate;
 };
 
 } // namespace ZeroTier


### PR DESCRIPTION
After doing #1998 , I noticed there were still spikes. I tracked it down to getifaddrs getting called in a loop. It's worse when you're on more networks or have many managed routes. 

This just caches the result of getifaddrs for 1 second. So getifaddrs doesn't get called 20 times in a row. 

I ran `gping` for 10 minutes. I am joined to 3 networks for this test. One of them has a ~30 routes. You can't see as many spikes if on just one network. 

dev (included 1998):
<img width="949" alt="dev 3 networks" src="https://github.com/zerotier/ZeroTierOne/assets/11598/62260d89-9c27-49f0-8204-f9060671e781">

this PR:
<img width="953" alt="patched 3 networks" src="https://github.com/zerotier/ZeroTierOne/assets/11598/6bf8b915-efd9-4745-9184-599f98bb3943">

It's a little less spikey and the spikes aren't as tall. 

`gping 10.211.55.6 10.147.19.149 -c magenta -b 600`


Please let me know if this is somehow a memory leak or something. 

