### PR TITLE
remove rustc --release flag

### DIFF
--- a/make-linux.mk
+++ b/make-linux.mk
@@ -62,7 +62,6 @@ ifeq ($(ZT_DEBUG),1)
 	override CXXFLAGS+=-Wall -Wno-deprecated -g -O -std=c++17 -pthread $(INCLUDES) $(DEFS)
 	ZT_TRACE=1
 	RUSTFLAGS=
-	CARGOFLAGS=
 	# The following line enables optimization for the crypto code, since
 	# C25519 in particular is almost UNUSABLE in -O0 even on a 3ghz box!
 node/Salsa20.o node/SHA512.o node/C25519.o node/Poly1305.o: CXXFLAGS=-Wall -O2 -g -pthread $(INCLUDES) $(DEFS)
@@ -72,8 +71,7 @@ else
 	CXXFLAGS?=-O3 -fstack-protector
 	override CXXFLAGS+=-Wall -Wno-deprecated -std=c++17 -pthread $(INCLUDES) -DNDEBUG $(DEFS)
 	LDFLAGS=-pie -Wl,-z,relro,-z,now
-	RUSTFLAGS=
-	CARGOFLAGS=--release
+	RUSTFLAGS=--release
 endif
 
 ifeq ($(ZT_QNAP), 1)
@@ -412,8 +410,8 @@ debug:	FORCE
 ifeq ($(ZT_SSO_SUPPORTED), 1)
 ifeq ($(ZT_EMBEDDED),)
 zeroidc:	FORCE
-#	export PATH=/root/.cargo/bin:$$PATH; cd zeroidc && cargo build -j1 $(CARGOFLAGS)
-	export PATH=/${HOME}/.cargo/bin:$$PATH; cd zeroidc && cargo build $(CARGOFLAGS)
+#	export PATH=/root/.cargo/bin:$$PATH; cd zeroidc && cargo rustc  -j1 $(RUSTFLAGS)
+	export PATH=/${HOME}/.cargo/bin:$$PATH; cd zeroidc && cargo rustc $(RUSTFLAGS)
 endif
 else
 zeroidc:
@@ -476,7 +474,6 @@ echo_flags:
 	@echo "echo_flags :: CXXFLAGS=$(CXXFLAGS)"
 	@echo "echo_flags :: LDFLAGS=$(LDFLAGS)"
 	@echo "echo_flags :: RUSTFLAGS=$(RUSTFLAGS)"
-	@echo "echo_flags :: CARGOFLAGS=$(CARGOFLAGS)"
 	@echo "=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~"
 
 debian: echo_flags

--- a/make-linux.mk
+++ b/make-linux.mk
@@ -71,7 +71,7 @@ else
 	CXXFLAGS?=-O3 -fstack-protector
 	override CXXFLAGS+=-Wall -Wno-deprecated -std=c++17 -pthread $(INCLUDES) -DNDEBUG $(DEFS)
 	LDFLAGS=-pie -Wl,-z,relro,-z,now
-	RUSTFLAGS=--release
+	RUSTFLAGS=
 endif
 
 ifeq ($(ZT_QNAP), 1)

--- a/make-linux.mk
+++ b/make-linux.mk
@@ -62,6 +62,7 @@ ifeq ($(ZT_DEBUG),1)
 	override CXXFLAGS+=-Wall -Wno-deprecated -g -O -std=c++17 -pthread $(INCLUDES) $(DEFS)
 	ZT_TRACE=1
 	RUSTFLAGS=
+	CARGOFLAGS=
 	# The following line enables optimization for the crypto code, since
 	# C25519 in particular is almost UNUSABLE in -O0 even on a 3ghz box!
 node/Salsa20.o node/SHA512.o node/C25519.o node/Poly1305.o: CXXFLAGS=-Wall -O2 -g -pthread $(INCLUDES) $(DEFS)
@@ -72,6 +73,7 @@ else
 	override CXXFLAGS+=-Wall -Wno-deprecated -std=c++17 -pthread $(INCLUDES) -DNDEBUG $(DEFS)
 	LDFLAGS=-pie -Wl,-z,relro,-z,now
 	RUSTFLAGS=
+	CARGOFLAGS=--release
 endif
 
 ifeq ($(ZT_QNAP), 1)
@@ -410,8 +412,8 @@ debug:	FORCE
 ifeq ($(ZT_SSO_SUPPORTED), 1)
 ifeq ($(ZT_EMBEDDED),)
 zeroidc:	FORCE
-#	export PATH=/root/.cargo/bin:$$PATH; cd zeroidc && cargo build -j1 $(RUSTFLAGS)
-	export PATH=/${HOME}/.cargo/bin:$$PATH; cd zeroidc && cargo build $(RUSTFLAGS)
+#	export PATH=/root/.cargo/bin:$$PATH; cd zeroidc && cargo build -j1 $(CARGOFLAGS)
+	export PATH=/${HOME}/.cargo/bin:$$PATH; cd zeroidc && cargo build $(CARGOFLAGS)
 endif
 else
 zeroidc:
@@ -474,6 +476,7 @@ echo_flags:
 	@echo "echo_flags :: CXXFLAGS=$(CXXFLAGS)"
 	@echo "echo_flags :: LDFLAGS=$(LDFLAGS)"
 	@echo "echo_flags :: RUSTFLAGS=$(RUSTFLAGS)"
+	@echo "echo_flags :: CARGOFLAGS=$(CARGOFLAGS)"
 	@echo "=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~"
 
 debian: echo_flags


### PR DESCRIPTION
The `--release` flag should be [applied to cargo, not rustc](https://stackoverflow.com/questions/45593026/unrecognized-option-release-when-compiling-with-rustc-in-release-mode). This causes the compiler to exit with code 1 since release is an unrecognized option.

Docker mcve against version 1.10.5 with [alpine](https://gitlab.alpinelinux.org/alpine/aports/-/commit/7f7b355d081655ed3fbbc6391f6aac987d2d4e2c)
```dockerfile
FROM alpine:edge

RUN apk update && \
    apk add --no-cache alpine-sdk wget && \
    addgroup root abuild

RUN mkdir "/root/.abuild"
RUN abuild-keygen -an
WORKDIR /build
RUN wget https://gitlab.alpinelinux.org/alpine/aports/-/raw/eab757ac9e60bc25cf5d0c5b07785b12e7a4bb04/community/zerotier-one/APKBUILD && \
    wget https://gitlab.alpinelinux.org/alpine/aports/-/raw/eab757ac9e60bc25cf5d0c5b07785b12e7a4bb04/community/zerotier-one/zerotier-one.initd
RUN abuild -F checksum && abuild -F -r
```

the patch can also be tested in docker
APKBUILD
```patch
source="$pkgname-$pkgver.tar.gz::https://github.com/zerotier/ZeroTierOne/archive/refs/tags/$pkgver.tar.gz
	$pkgname.initd
+	rustc-release.patch
	"
```

rustc-release.patch
```patch
diff -Nurp a/C/make-linux.mk b/C/make-linux.mk
--- a/make-linux.mk	2023-05-19 13:12:27.946482400 -0400
+++ b/make-linux.mk	2023-05-19 13:19:00.633535900 -0400
@@ -71,7 +71,7 @@ else
 	CXXFLAGS?=-O3 -fstack-protector
 	override CXXFLAGS+=-Wall -Wno-deprecated -std=c++17 -pthread $(INCLUDES) -DNDEBUG $(DEFS)
 	LDFLAGS=-pie -Wl,-z,relro,-z,now
-	RUSTFLAGS=--release
+	RUSTFLAGS=
 endif
 
 ifeq ($(ZT_QNAP), 1)
```