### PR TITLE
Don't apply default route until zerotier is "online"

### DIFF
--- a/service/OneService.cpp
+++ b/service/OneService.cpp
@@ -2617,8 +2617,9 @@ public:
 					r->second->sync();
 			}
 			for(std::map< InetAddress, SharedPtr<ManagedRoute> >::iterator r(n.managedRoutes().begin());r!=n.managedRoutes().end();++r) {
-				if (r->second->via())
+				if (r->second->via() && (!r->second->target().isDefaultRoute() || _node->online())) {
 					r->second->sync();
+				}
 			}
 		}
 


### PR DESCRIPTION
I was running into issues with restarting the zerotier service while "full tunnel" mode is enabled.
When zerotier first boots, it gets network state from the cache on disk. So it immediately applies all the routes it knew about before it shutdown.
The network config may have change in this time.
If it has, then your default route is via a route
you are blocked from talking on. So you  can't get the current network config, so your internet does not work.
That's one theory. In any case,  starting zerotier with full tunnel enabled can fail and this helps. 

Other options include
- don't use cached network state on boot
- find a better criteria than "online"

Looking for any thoughts on how this might break other things