### PR TITLE
Fix bad variable name error during build on WSL

### DIFF
--- a/make-linux.mk
+++ b/make-linux.mk
@@ -429,8 +429,8 @@ debug:	FORCE
 ifeq ($(ZT_SSO_SUPPORTED), 1)
 ifeq ($(ZT_EMBEDDED),)
 zeroidc:	FORCE
-#	export PATH=/root/.cargo/bin:$$PATH; cd zeroidc && cargo build -j1 $(RUSTFLAGS)
-	export PATH=/${HOME}/.cargo/bin:$$PATH; cd zeroidc && cargo build $(RUSTFLAGS)
+#	export PATH=/root/.cargo/bin:"$$PATH"; cd zeroidc && cargo build -j1 $(RUSTFLAGS)
+	export PATH=/${HOME}/.cargo/bin:"$$PATH"; cd zeroidc && cargo build $(RUSTFLAGS)
 endif
 else
 zeroidc:


### PR DESCRIPTION
WSL appends Windows environment variables to PATH, which causes `/bin/sh` to report a bad variable name error:
```
export PATH=//home/user/.cargo/bin:$PATH; cd zeroidc && cargo build --release
/bin/sh: 1: export: Files/Git/cmd:/mnt/c/Program: bad variable name
make: *** [make-linux.mk:433: zeroidc] Error 2
```
This fix adds double quotes to avoid this problem. See also  https://askubuntu.com/questions/1354999/bad-variable-name-error-on-wsl