### PR TITLE
suppress warnings: comparison of integers of different signs: 'int64_…

### DIFF
--- a/node/Bond.cpp
+++ b/node/Bond.cpp
@@ -20,6 +20,11 @@
 #include <string>
 #include <cinttypes> // for PRId64, etc. macros
 
+// FIXME: remove this suppression and actually fix warnings
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#endif
+
 namespace ZeroTier {
 
 static unsigned char s_freeRandomByteCounter = 0;

--- a/node/Node.cpp
+++ b/node/Node.cpp
@@ -36,6 +36,11 @@
 #include "Trace.hpp"
 #include "Metrics.hpp"
 
+// FIXME: remove this suppression and actually fix warnings
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#endif
+
 namespace ZeroTier {
 
 /****************************************************************************/


### PR DESCRIPTION
…t' (aka 'long') and 'uint64_t' (aka 'unsigned long') [-Wsign-compare]