### PR TITLE
fix warning: 'OS_STRING' macro redefined [-Wmacro-redefined]

### DIFF
--- a/ext/miniupnpc/minisoap.c
+++ b/ext/miniupnpc/minisoap.c
@@ -21,12 +21,14 @@
 #include "minisoap.h"
 
 #ifdef _WIN32
+#undef OS_STRING
 #define OS_STRING "Win32"
 #define MINIUPNPC_VERSION_STRING "2.0"
 #define UPNP_VERSION_STRING "UPnP/1.1"
 #endif
 
 #ifdef __ANDROID__
+#undef OS_STRING
 #define OS_STRING "Android"
 #define MINIUPNPC_VERSION_STRING "2.0"
 #define UPNP_VERSION_STRING "UPnP/1.1"

--- a/ext/miniupnpc/miniwget.c
+++ b/ext/miniupnpc/miniwget.c
@@ -49,12 +49,14 @@
 #endif /* MIN */
 
 #ifdef _WIN32
+#undef OS_STRING
 #define OS_STRING "Win32"
 #define MINIUPNPC_VERSION_STRING "2.0"
 #define UPNP_VERSION_STRING "UPnP/1.1"
 #endif
 
 #ifdef __ANDROID__
+#undef OS_STRING
 #define OS_STRING "Android"
 #define MINIUPNPC_VERSION_STRING "2.0"
 #define UPNP_VERSION_STRING "UPnP/1.1"


### PR DESCRIPTION
Even though this is in ext, these particular chunks of code were added by us, so are ok to modify.