### PR TITLE
Disable executable stacks on assembly objects

### DIFF
--- a/make-linux.mk
+++ b/make-linux.mk
@@ -357,6 +357,9 @@ endif
 override CFLAGS+=-fPIC -fPIE
 override CXXFLAGS+=-fPIC -fPIE
 
+# Non-executable stack
+override ASFLAGS+=--noexecstack
+
 .PHONY: all
 all:	one
 


### PR DESCRIPTION
Add `--noexecstack` to the assembler flags so the resulting binary will link with a non-executable stack.

Fixes zerotier/ZeroTierOne#1179