### PR TITLE
Don't skip hellos when there are no paths available

### DIFF
--- a/node/Node.cpp
+++ b/node/Node.cpp
@@ -248,9 +248,15 @@ public:
 		const std::vector<InetAddress> *const alwaysContactEndpoints = _alwaysContact.get(p->address());
 		if (alwaysContactEndpoints) {
 
-			// Contact upstream peers as infrequently as possible
 			ZT_PeerRole role = RR->topology->role(p->address());
+
+			// Contact upstream peers as infrequently as possible
 			int roleBasedTimerScale = (role == ZT_PEER_ROLE_LEAF) ? 2 : 16;
+
+			// Unless we don't any have paths to the roots, then we shouldn't wait a long time to contact them
+			bool hasPaths = p->paths(RR->node->now()).size() > 0;
+			roleBasedTimerScale = (role != ZT_PEER_ROLE_LEAF && !hasPaths) ? 0 : roleBasedTimerScale;
+
 			if ((RR->node->now() - p->lastSentFullHello()) <= (ZT_PATH_HEARTBEAT_PERIOD * roleBasedTimerScale)) {
 				return;
 			}


### PR DESCRIPTION
For discussion, 

working on #2082

This change helps with the issue, but i can imagine some down sides. 

This chunk of code was last changed in 

e1f60e3f8 - Behavioral changes to multipath balance modes (See: #1745 and #1753) 

right before 1.10.2 which matches some of the user's observations.


Test it out on a mac:
turn off wifi
start zerotier
turn on wifi
look at zerotier-cli peers and or try to ping a remote node

try it with and without the patch. 


We can come up with some smarter logic for deciding when to ping or not. And of course I'll remove the printfs and other junk. 