### PR TITLE
fix macos default route again

### DIFF
--- a/osdep/MacDNSHelper.mm
+++ b/osdep/MacDNSHelper.mm
@@ -107,7 +107,6 @@ void MacDNSHelper::removeDNS(uint64_t nwid)
 bool MacDNSHelper::addIps4(uint64_t nwid, const MAC mac, const char *dev, const std::vector<InetAddress>& addrs)
 {
     const char* ipStr = {0};
-    const char* ipStr2 = {0};
     char buf2[256] = {0};
 
     bool hasV4 = false;
@@ -116,7 +115,6 @@ bool MacDNSHelper::addIps4(uint64_t nwid, const MAC mac, const char *dev, const 
             hasV4 = true;
 
             ipStr = addrs[i].toIpString(buf2);
-            ipStr2 = addrs[i].toIpString(buf2);
 
             break;
         }
@@ -141,7 +139,8 @@ bool MacDNSHelper::addIps4(uint64_t nwid, const MAC mac, const char *dev, const 
     CFStringRef cfdev = CFStringCreateWithCString(NULL, dev, kCFStringEncodingUTF8);
 
     CFStringRef cfserver = CFStringCreateWithCString(NULL, "127.0.0.1", kCFStringEncodingUTF8);
-    CFStringRef cfrouter = CFStringCreateWithCString(NULL, ipStr2, kCFStringEncodingUTF8);
+    // using the ip from the zerotier network breaks routing on the mac
+    CFStringRef cfrouter = CFStringCreateWithCString(NULL, "127.0.0.1", kCFStringEncodingUTF8);
 
     const int SIZE = 4;
     CFStringRef keys[SIZE];

--- a/osdep/PortMapper.cpp
+++ b/osdep/PortMapper.cpp
@@ -14,7 +14,7 @@
 #ifdef ZT_USE_MINIUPNPC
 
 // Uncomment to dump debug messages
-#define ZT_PORTMAPPER_TRACE 1
+//#define ZT_PORTMAPPER_TRACE 1
 
 #ifdef __ANDROID__
 #include <android/log.h>


### PR DESCRIPTION
see commit fb6af1971 * Fix network DNS on macOS

Adding that stuff to System Config causes this extra route to be added which breaks ipv4 default route.
We found out by trial and error that adding "127.0.0.1" instead of the network'd ip address makes it work without breaking dns either. 

----
~~couldn't figure out how to fix it in SystemConfiguration so here we are~~

~~We also moved the dns helper stuff to before the syncIps stuff to help with a race condition. It didn't always work when you re-joined a network with default route enabled.~~