### PR TITLE
Append noexecstack to linker flags instead of assembler flags

### DIFF
--- a/make-linux.mk
+++ b/make-linux.mk
@@ -358,7 +358,7 @@ override CFLAGS+=-fPIC -fPIE
 override CXXFLAGS+=-fPIC -fPIE
 
 # Non-executable stack
-override ASFLAGS+=--noexecstack
+override LDFLAGS+=-Wl,-z,noexecstack
 
 .PHONY: all
 all:	one


### PR DESCRIPTION
* Better compatibility with LLVM toolchain where clang -c doesn't support the flag, but the linker does. LLD already defaults to noexecstack, but adding it in the linker phase will avoid errors about unsupported options.

```
clang -c --noexecstack  -o ext/x64-salsa2012-asm/salsa2012.o ext/x64-salsa2012-asm/salsa2012.s
1 warning generated.
clang: error: unsupported option '--noexecstack'
make: *** [<builtin>: ext/x64-salsa2012-asm/salsa2012.o] Error 1
```

```
 $ scanelf -e zerotier-one
 TYPE   STK/REL/PTL FILE 
ET_DYN RW- R-- RW- zerotier-one
```

https://github.com/llvm/llvm-project/issues/57009#issuecomment-1208760473