### PR TITLE
Respect user LDFLAGS

### DIFF
--- a/make-linux.mk
+++ b/make-linux.mk
@@ -71,7 +71,7 @@ else
 	override CFLAGS+=-Wall -Wno-deprecated -pthread $(INCLUDES) -DNDEBUG $(DEFS)
 	CXXFLAGS?=-O3 -fstack-protector
 	override CXXFLAGS+=-Wall -Wno-deprecated -std=c++17 -pthread $(INCLUDES) -DNDEBUG $(DEFS)
-	LDFLAGS=-pie -Wl,-z,relro,-z,now
+	LDFLAGS?=-pie -Wl,-z,relro,-z,now
 	ZT_CARGO_FLAGS=--release
 endif
 


### PR DESCRIPTION
* Respect user LDFLAGS instead of replacing them.

Previously used on Gentoo where people want their LDFLAGS to be respected for various reasons.

https://github.com/gentoo/gentoo/blob/dbe0856cb9efde3dcd87ffb9f8b568aac2132e4a/net-misc/zerotier/files/zerotier-1.10.1-respect-ldflags.patch