### PR TITLE
Remove extra '/'

### DIFF
--- a/one.cpp
+++ b/one.cpp
@@ -1210,7 +1210,7 @@ static int cli(int argc,char **argv)
 				FSRefMakePath(&fsref, path, sizeof(path)) == noErr) {
 
 		} else if (getenv("SUDO_USER")) {
-			sprintf((char*)path, "/Users/%s/Desktop/", getenv("SUDO_USER"));
+			sprintf((char*)path, "/Users/%s/Desktop", getenv("SUDO_USER"));
 		} else {
 			fprintf(stdout, "%s", dump.str().c_str());
 			return 0;


### PR DESCRIPTION
On macOS, dump gives this output:
% sudo zerotier-cli dump
Writing dump to: /Users/brenton/Desktop//zerotier_dump.txt

No reason for extra '/' in path