### PR TITLE
Add ARM architectures to Synology DSM7

### DIFF
--- a/pkg/synology/dsm7-docker/README.md
+++ b/pkg/synology/dsm7-docker/README.md
@@ -1,3 +1,8 @@
 ## Docker image for Synology's DSM7
 
 Documentation: [docs.zerotier.com/devices/synology](https://docs.zerotier.com/devices/synology)
+
+### Build & Push changes to DockerHub
+```shell
+./build.sh build
+```

--- a/pkg/synology/dsm7-docker/build.sh
+++ b/pkg/synology/dsm7-docker/build.sh
@@ -3,19 +3,17 @@
 ZTO_VER=$(git describe --tags $(git rev-list --tags --max-count=1))
 ZTO_COMMIT=$(git rev-parse HEAD)
 
-build()
-{
-  sudo docker build --load --rm -t zerotier-synology . --build-arg ZTO_COMMIT=${ZTO_COMMIT} --build-arg ZTO_VER=${ZTO_VER}
-  LATEST_DOCKER_IMAGE_HASH=$(sudo docker images -q zerotier-synology)
-  sudo docker tag ${LATEST_DOCKER_IMAGE_HASH} zerotier/zerotier-synology:${ZTO_VER}
-  sudo docker tag ${LATEST_DOCKER_IMAGE_HASH} zerotier/zerotier-synology:latest
-}
-
-push()
-{
+build() {
   sudo docker login --username=${DOCKERHUB_USERNAME}
-  sudo docker push zerotier/zerotier-synology:${ZTO_VER}
-  sudo docker push zerotier/zerotier-synology:latest
+
+  sudo docker buildx build \
+    --push \
+    --platform linux/arm/v7,linux/arm64/v8,linux/amd64 \
+    --tag zerotier/zerotier-synology:${ZTO_VER} \
+    --tag zerotier/zerotier-synology:latest \
+    --build-arg ZTO_COMMIT=${ZTO_COMMIT} \
+    --build-arg ZTO_VER=${ZTO_VER} \
+    .
 }
 
 "$@"


### PR DESCRIPTION
# Possibly Addresses

I _think_ this may address https://github.com/zerotier/ZeroTierOne/issues/1873 & https://github.com/zerotier/ZeroTierOne/issues/1957 , possibly https://github.com/zerotier/ZeroTierOne/issues/2153 too, but unsure (not enough details in issue).

# Testing

I have an example of this change published [on my dockerhub account (https://hub.docker.com/repository/docker/chriscarini/zerotier-synology/general)](https://hub.docker.com/repository/docker/chriscarini/zerotier-synology/general):
<img width="1719" alt="Screenshot 2023-11-03 at 18 21 51" src="https://github.com/zerotier/ZeroTierOne/assets/6374067/b81b3b49-b70b-4caa-a6de-144e349bfcdf">

I've been running for ~15 days w/o any issues (according to the logs; see below):
<img width="1280" alt="Screenshot 2023-11-03 at 18 15 32" src="https://github.com/zerotier/ZeroTierOne/assets/6374067/ad96e2e3-3680-47db-985b-45d067c5b7b8">

I'd rather this be contributed back to the main project (i.e. https://github.com/zerotier/ZeroTierOne), and delete the image published to my personal DockerHub account.

# Next Steps

After this PR is merged, someone w/ the respective permissions to the zerotier dockerhub would need to run the below command to get a new tag/version published out to DockerHub w/ the new architectures:
```
./build.sh build
```

**CC:** @joseph-henry (who I believe first added the DSM7 packaging to this repo)
