### PR TITLE
fix tcp-proxy makefile pthread link

### DIFF
--- a/tcp-proxy/Makefile
+++ b/tcp-proxy/Makefile
@@ -3,7 +3,7 @@ CXX=$(shell which clang++ g++ c++ 2>/dev/null | head -n 1)
 INCLUDES?=-I../ext/prometheus-cpp-lite-1.0/core/include  -I../ext/prometheus-cpp-lite-1.0/simpleapi/include
 
 all:
-	$(CXX) -O3 -fno-rtti $(INCLUDES) -std=c++11 -frtti  -o tcp-proxy tcp-proxy.cpp ../node/Metrics.cpp
+	$(CXX) -O3 -fno-rtti $(INCLUDES) -std=c++11 -pthread -frtti  -o tcp-proxy tcp-proxy.cpp ../node/Metrics.cpp
 
 clean:
 	rm -f *.o tcp-proxy *.dSYM


### PR DESCRIPTION
When compiling tcp-proxy.cpp in the default github codespace, a link error occurs due to the absence of the pthread identifier in the Makefile of tcp-proxy.

```
# make
/usr/bin/clang++ -O3 -fno-rtti -I../ext/prometheus-cpp-lite-1.0/core/include  -I../ext/prometheus-cpp-lite-1.0/simpleapi/include -std=c++11 -frtti  -o tcp-proxy tcp-proxy.cpp ../node/Metrics.cpp
/tmp/Metrics-8c05db.o: In function `_GLOBAL__sub_I_Metrics.cpp':
Metrics.cpp:(.text.startup+0x11b): undefined reference to `pthread_create'
clang-15: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [Makefile:6: all] Error 1
```