### PR TITLE
Add `name` field to embedded controller networks

### DIFF
--- a/controller/EmbeddedNetworkController.cpp
+++ b/controller/EmbeddedNetworkController.cpp
@@ -1068,6 +1068,7 @@ void EmbeddedNetworkController::configureHTTPControlPlane(
 		if (b.count("noAutoAssignIps")) member["noAutoAssignIps"] = OSUtils::jsonBool(b["noAutoAssignIps"], false);
 		if (b.count("authenticationExpiryTime")) member["authenticationExpiryTime"] = (uint64_t)OSUtils::jsonInt(b["authenticationExpiryTime"], 0ULL);
 		if (b.count("authenticationURL")) member["authenticationURL"] = OSUtils::jsonString(b["authenticationURL"], "");
+		if (b.count("name")) member["name"] = OSUtils::jsonString(b["name"], "");
 
 		if (b.count("remoteTraceTarget")) {
 			const std::string rtt(OSUtils::jsonString(b["remoteTraceTarget"],""));


### PR DESCRIPTION
Putting up here as a place to discuss. I guess we'd might want to put a limit on the length of the string? 

Storing the `name` is just this line;

`if (b.count("name")) member["name"] = OSUtils::jsonString(b["name"], "");`

this new /member2 endpoint is just a place to test, but I want to talk about that too...

We'd have to add `name` to GET /network/{nwid}/member/{ID} to as well