### PR TITLE
Add homeDir to info json

### DIFF
--- a/service/OneService.cpp
+++ b/service/OneService.cpp
@@ -2041,6 +2041,7 @@ public:
             settings["primaryPort"] = OSUtils::jsonInt(settings["primaryPort"],(uint64_t)_primaryPort) & 0xffff;
             settings["secondaryPort"] = OSUtils::jsonInt(settings["secondaryPort"],(uint64_t)_ports[1]) & 0xffff;
             settings["tertiaryPort"] = OSUtils::jsonInt(settings["tertiaryPort"],(uint64_t)_tertiaryPort) & 0xffff;
+            settings["homeDir"] = _homePath;
             // Enumerate all local address/port pairs that this node is listening on
             std::vector<InetAddress> boundAddrs(_binder.allBoundLocalInterfaceAddresses());
             auto boundAddrArray = json::array();


### PR DESCRIPTION
Want to show it in UIs. So need to get it via API.

It's also a pain to look up. You have to go to external docs.

zerotier-cli info -j

```json
"config": {
  "settings": {
   "allowTcpFallbackRelay": true,
   "forceTcpRelay": true,
   "homeDir": "/Library/Application Support/ZeroTier/One",
```

under `settings` because it's a setting you can set when you start zerotier-one
`Usage: /var/lib/zerotier-one/zerotier-one [-switches] [home directory]`