### PR TITLE
Comment out debug traces in Rules Engine

### DIFF
--- a/node/Network.cpp
+++ b/node/Network.cpp
@@ -114,14 +114,14 @@ static _doZtFilterResult _doZtFilter(
 	// uncomment for easier debugging fprintf
 	// if (!ztDest) { return DOZTFILTER_ACCEPT; }
 #ifdef ZT_TRACE
-	char buf[40], buf2[40];
-	fprintf(stderr, "\nsrc %s dest %s inbound: %d ethertype %u", ztSource.toString(buf), ztDest.toString(buf2), inbound, etherType);
+	//char buf[40], buf2[40];
+	//fprintf(stderr, "\nsrc %s dest %s inbound: %d ethertype %u", ztSource.toString(buf), ztDest.toString(buf2), inbound, etherType);
 #endif
 
 	for(unsigned int rn=0;rn<ruleCount;++rn) {
 		const ZT_VirtualNetworkRuleType rt = (ZT_VirtualNetworkRuleType)(rules[rn].t & 0x3f);
 #ifdef ZT_TRACE
-		fprintf(stderr, "\n%02u %02d", rn, rt);
+		//fprintf(stderr, "\n%02u %02d", rn, rt);
 #endif
 
 		// First check if this is an ACTION
@@ -135,19 +135,19 @@ static _doZtFilterResult _doZtFilter(
 					case ZT_NETWORK_RULE_ACTION_DROP: {
 						if (!!skipDrop) {
 #ifdef ZT_TRACE
-							fprintf(stderr, "\tskip Drop");
+							//fprintf(stderr, "\tskip Drop");
 #endif
 							skipDrop = 0; continue;
 						}
 #ifdef ZT_TRACE
-						fprintf(stderr, "\tDrop\n");
+						//fprintf(stderr, "\tDrop\n");
 #endif
 						return DOZTFILTER_DROP;
 					}
 
 					case ZT_NETWORK_RULE_ACTION_ACCEPT: {
 #ifdef ZT_TRACE
-						fprintf(stderr, "\tAccept\n");
+						//fprintf(stderr, "\tAccept\n");
 #endif
 						return (superAccept ? DOZTFILTER_SUPER_ACCEPT : DOZTFILTER_ACCEPT); // match, accept packet
 					}
@@ -473,12 +473,12 @@ static _doZtFilterResult _doZtFilter(
 				if ((localTag != &(nconf.tags[nconf.tagCount]))&&(localTag->id() == rules[rn].v.tag.id)) {
 					const Tag *const remoteTag = ((membership) ? membership->getTag(nconf,rules[rn].v.tag.id) : (const Tag *)0);
 #ifdef ZT_TRACE
-					fprintf(stderr, "\tlocal tag [%u: %u] remote tag [%u: %u] match [%u]",
+					/*fprintf(stderr, "\tlocal tag [%u: %u] remote tag [%u: %u] match [%u]",
 							!!localTag ? localTag->id() : 0,
 							!!localTag ? localTag->value() : 0,
 							!!remoteTag ? remoteTag->id() : 0,
 							!!remoteTag ? remoteTag->value() : 0,
-							thisRuleMatches);
+							thisRuleMatches);*/
 #endif
 					if (remoteTag) {
 						const uint32_t ltv = localTag->value();
@@ -501,7 +501,7 @@ static _doZtFilterResult _doZtFilter(
 						if ((inbound)&&(!superAccept)) {
 							thisRuleMatches = hardNo;
 #ifdef ZT_TRACE
-							fprintf(stderr, "\tinbound ");
+							//fprintf(stderr, "\tinbound ");
 #endif
 						} else {
 							// Outbound side is not strict since if we have to match both tags and
@@ -512,7 +512,7 @@ static _doZtFilterResult _doZtFilter(
 							skipDrop = 1;
 							thisRuleMatches = hardYes;
 #ifdef ZT_TRACE
-							fprintf(stderr, "\toutbound ");
+							//fprintf(stderr, "\toutbound ");
 #endif
 						}
 					}
@@ -524,13 +524,13 @@ static _doZtFilterResult _doZtFilter(
 			case ZT_NETWORK_RULE_MATCH_TAG_RECEIVER: {
 					const Tag *const localTag = std::lower_bound(&(nconf.tags[0]),&(nconf.tags[nconf.tagCount]),rules[rn].v.tag.id,Tag::IdComparePredicate());
 #ifdef ZT_TRACE
-					const Tag *const remoteTag = ((membership) ? membership->getTag(nconf,rules[rn].v.tag.id) : (const Tag *)0);
+					/*const Tag *const remoteTag = ((membership) ? membership->getTag(nconf,rules[rn].v.tag.id) : (const Tag *)0);
 					fprintf(stderr, "\tlocal tag [%u: %u] remote tag [%u: %u] match [%u]",
 							!!localTag ? localTag->id() : 0,
 							!!localTag ? localTag->value() : 0,
 							!!remoteTag ? remoteTag->id() : 0,
 							!!remoteTag ? remoteTag->value() : 0,
-							thisRuleMatches);
+							thisRuleMatches);*/
 #endif
 				if (superAccept) {
 					skipDrop = 1;


### PR DESCRIPTION
I think these are fine to leave in for now but they're too noisy for `ZT_TRACE` since it's per-packet. Maybe once we're done tweaking the rules engine we can remove them entirely