### PR TITLE
Fix mac handling in rules parser

### DIFF
--- a/controller/EmbeddedNetworkController.cpp
+++ b/controller/EmbeddedNetworkController.cpp
@@ -315,12 +315,14 @@ static bool _parseRule(json &r,ZT_VirtualNetworkRule &rule)
 		return true;
 	} else if (t == "MATCH_MAC_SOURCE") {
 		rule.t |= ZT_NETWORK_RULE_MATCH_MAC_SOURCE;
-		const std::string mac(Utils::cleanMac(OSUtils::jsonString(r["mac"],"0")));
+		std::string mac(OSUtils::jsonString(r["mac"],"0"));
+		Utils::cleanMac(mac);
 		Utils::unhex(mac.c_str(),(unsigned int)mac.length(),rule.v.mac,6);
 		return true;
 	} else if (t == "MATCH_MAC_DEST") {
 		rule.t |= ZT_NETWORK_RULE_MATCH_MAC_DEST;
-		const std::string mac(Utils::cleanMac(OSUtils::jsonString(r["mac"],"0")));
+		std::string mac(OSUtils::jsonString(r["mac"],"0"));
+		Utils::cleanMac(mac);
 		Utils::unhex(mac.c_str(),(unsigned int)mac.length(),rule.v.mac,6);
 		return true;
 	} else if (t == "MATCH_IPV4_SOURCE") {

--- a/controller/EmbeddedNetworkController.cpp
+++ b/controller/EmbeddedNetworkController.cpp
@@ -315,12 +315,12 @@ static bool _parseRule(json &r,ZT_VirtualNetworkRule &rule)
 		return true;
 	} else if (t == "MATCH_MAC_SOURCE") {
 		rule.t |= ZT_NETWORK_RULE_MATCH_MAC_SOURCE;
-		const std::string mac(OSUtils::jsonString(r["mac"],"0"));
+		const std::string mac(Utils::cleanMac(OSUtils::jsonString(r["mac"],"0")));
 		Utils::unhex(mac.c_str(),(unsigned int)mac.length(),rule.v.mac,6);
 		return true;
 	} else if (t == "MATCH_MAC_DEST") {
 		rule.t |= ZT_NETWORK_RULE_MATCH_MAC_DEST;
-		const std::string mac(OSUtils::jsonString(r["mac"],"0"));
+		const std::string mac(Utils::cleanMac(OSUtils::jsonString(r["mac"],"0")));
 		Utils::unhex(mac.c_str(),(unsigned int)mac.length(),rule.v.mac,6);
 		return true;
 	} else if (t == "MATCH_IPV4_SOURCE") {

--- a/node/Utils.hpp
+++ b/node/Utils.hpp
@@ -24,6 +24,7 @@
 #include <stdexcept>
 #include <vector>
 #include <map>
+#include <algorithm>
 
 #if defined(__FreeBSD__)
 #include <sys/endian.h>
@@ -849,6 +850,19 @@ public:
 	 * Hexadecimal characters 0-f
 	 */
 	static const char HEXCHARS[16];
+
+	/*
+	 * Remove `-` and `:` from a MAC address (in-place).
+	 *
+	 * @param mac The MAC address
+	*/
+	static inline void cleanMac(std::string& mac)
+	{
+		auto start = mac.begin();
+		auto end = mac.end();
+		auto new_end = std::remove_if(start, end, [](char c) { return c == 45 || c == 58; });
+		mac.erase(new_end, end);
+	}
 };
 
 } // namespace ZeroTier


### PR DESCRIPTION
This branch pulls in changes from https://github.com/zerotier/ZeroTierOne/pull/2176 and attempts to fix some bad logic.

I've only unit tested the `cleanMac` function but have not done a full end-to-end test yet.