### PR TITLE
Consider ::ffff:127.0.0.1 as a loopback address

### DIFF
--- a/node/InetAddress.cpp
+++ b/node/InetAddress.cpp
@@ -132,7 +132,20 @@ InetAddress::IpScope InetAddress::ipScope() const
 					return IP_SCOPE_PRIVATE;        // fc00::/7
 				}
 			}
+
+			// :::ffff:127.0.0.1
+			// 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0x7f, 0, 0, 1
 			unsigned int k = 0;
+			while ((!ip[k])&&(k < 9)) {
+				++k;
+			}
+			if (k == 9) {
+				if (ip[10] == 0xff && ip[11] == 0xff && ip[12] == 0x7f) {
+					return IP_SCOPE_LOOPBACK;
+				}
+			}
+
+			k = 0;
 			while ((!ip[k])&&(k < 15)) {
 				++k;
 			}


### PR DESCRIPTION
cpp-httplib  sets IPV6_V6ONLY to false on it's sockets. On FreeBSD, this makes all ipv4 addresses get get prefixed with `::ffff:`. It makes them into IPv4 mapped IPv6 addresses.

This is a partial fix for #2151. The cli will work again. Something should probably also be adjusted with httplib.

If you want to, for example, use the `allowManagementFrom` option in local.conf
you will need to prefix it with "::ffff:", "::ffff:1.2.3.4" which is a little surprising and inconsistent between BSD and other OSs.

Thanks @dch for figuring this out. We used your example code but tried to make it match with what already exists. 


```
root@vultr:~/ZeroTierOne # uname -a
FreeBSD vultr.guest 14.0-RELEASE-p3 FreeBSD 14.0-RELEASE-p3 #0: Mon Dec 11 04:56:01 UTC 2023     root@amd64-builder.daemonology.net:/usr/obj/usr/src/amd64.amd64/sys/GENERIC amd64
root@vultr:~/ZeroTierOne # ./zerotier-cli info
200 info ad521db9aa 1.12.2 ONLINE
```