### PR TITLE
Enable IPV6_V6ONLY flag to increase reliability of IPv4 service

### DIFF
--- a/ext/cpp-httplib/httplib.h
+++ b/ext/cpp-httplib/httplib.h
@@ -3163,13 +3163,13 @@ socket_t create_socket(const std::string &host, const std::string &ip, int port,
     if (socket_options) { socket_options(sock); }
 
     if (rp->ai_family == AF_INET6) {
-      auto no = 0;
+      auto yes = 1;
 #ifdef _WIN32
       setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY,
-                 reinterpret_cast<const char *>(&no), sizeof(no));
+                 reinterpret_cast<const char *>(&yes), sizeof(yes));
 #else
       setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY,
-                 reinterpret_cast<const void *>(&no), sizeof(no));
+                 reinterpret_cast<const void *>(&yes), sizeof(yes));
 #endif
     }
 


### PR DESCRIPTION
This PR fixes #2342.

https://github.com/yhirose/cpp-httplib/commit/b2203bb05aa241a3dd00719c8afd07d82900ba3d explicitly disables the IPV6_V6ONLY flag, making the IPv6 socket bind to both IPv4 and IPv6, leaving the IPv4 socket (or the IPv4 part of the IPv6 dual-stack socket?) unable to bind, as mentioned [here](https://stackoverflow.com/a/2804499).

ZeroTierOne [explicitly binds to both IPv4 and IPv6](https://github.com/zerotier/ZeroTierOne/blob/dev/service/OneService.cpp#L2317-L2356), this is not valid while the IPV6_V6ONLY flag is disabled.

To resolve the issue, this PR makes ZeroTierOne not utilize a dual-stack IPv6 socket by explicitly enabling the IPV6_V6ONLY flag.