### PR TITLE
Lower ZT_MIN_PHYSMTU

### DIFF
--- a/include/ZeroTierOne.h
+++ b/include/ZeroTierOne.h
@@ -84,7 +84,7 @@ extern "C" {
 /**
  * Minimum UDP payload size allowed
  */
-#define ZT_MIN_PHYSMTU 1400
+#define ZT_MIN_PHYSMTU 510
 
 /**
  * Maximum physical interface name length. This number is gigantic because of Windows.


### PR DESCRIPTION
regarding #2361

This constant is only used in one place:

https://github.com/zerotier/ZeroTierOne/blob/d9d58c8bdef89c9beb7325c67777f45c822fc949/node/Topology.hpp#L419-L425

This change can't affect anything unless the user configures this value in their local.conf