### PR TITLE
Fix build error under certain character sets in Windows

### DIFF
--- a/ext/prometheus-cpp-lite-1.0/core/include/prometheus/client_metric.h
+++ b/ext/prometheus-cpp-lite-1.0/core/include/prometheus/client_metric.h
@@ -8,6 +8,7 @@
 namespace prometheus {
 
   // структура, в которую копируются значения метрик перед их сериализацией
+  
   struct ClientMetric {
 
     // Label


### PR DESCRIPTION
The header file `client_metric.h` of the third-party library `prometheus-cpp-lite-1.0` contains a comment with non-ASCII encoding. Since this file is saved in Windows-1251 encoding instead of Unicode, when using Visual Studio to compile, it will parse the file using the local system's character set.
On some Windows systems where the default character set is a multi-byte encoding, this may cause the last character of the comment line and the following newline character(\x0a) to be interpreted as a single character. As a result, the line ` struct ClientMetric { `could be commented out and causing the build to fail. Simply add some spaces after non-ASCII comment may avoid this error.
![image](https://github.com/user-attachments/assets/d133bab8-2118-4440-a72a-4dcb6361bb7d)
