### PR TITLE
Update upload-artifact action to use v4

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -44,7 +44,7 @@ jobs:
         sudo ./.github/workflows/validate-linux.sh
 
     - name: Archive test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{github.sha}}-test-results
         path: "*test-results*"


### PR DESCRIPTION
V3 is no longer supported and throws an error on use