### PR TITLE
Fix potential vulnerable cloned functions

### DIFF
--- a/ext/hiredis-0.14.1/sds.c
+++ b/ext/hiredis-0.14.1/sds.c
@@ -194,7 +194,7 @@ void sdsclear(sds s) {
 sds sdsMakeRoomFor(sds s, size_t addlen) {
     void *sh, *newsh;
     size_t avail = sdsavail(s);
-    size_t len, newlen;
+    size_t len, newlen, reqlen;
     char type, oldtype = s[-1] & SDS_TYPE_MASK;
     int hdrlen;
 
@@ -203,7 +203,8 @@ sds sdsMakeRoomFor(sds s, size_t addlen) {
 
     len = sdslen(s);
     sh = (char*)s-sdsHdrSize(oldtype);
-    newlen = (len+addlen);
+    reqlen = newlen = (len+addlen);
+    assert(newlen > len);   /* Catch size_t overflow */
     if (newlen < SDS_MAX_PREALLOC)
         newlen *= 2;
     else
@@ -217,6 +218,7 @@ sds sdsMakeRoomFor(sds s, size_t addlen) {
     if (type == SDS_TYPE_5) type = SDS_TYPE_8;
 
     hdrlen = sdsHdrSize(type);
+    assert(hdrlen + newlen + 1 > reqlen);  /* Catch size_t overflow */
     if (oldtype==type) {
         newsh = s_realloc(sh, hdrlen+newlen+1);
         if (newsh == NULL) return NULL;


### PR DESCRIPTION
Hi Development team,

I identified vulnerabilities in a clone function sdsMakeRoomFor() in `ext/hiredis-0.14.1/sds.c` sourced from [redis/redis](https://github.com/redis/redis). These issues, originally reported in [CVE-2021-41099](https://nvd.nist.gov/vuln/detail/cve-2021-41099), were resolved in the redis repository via this commit https://github.com/redis/redis/commit/c6ad876774f3cc11e32681ea02a2eead00f2c521.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you for your time and attention!