### PR TITLE
Fix potential vulnerable cloned functions

### DIFF
--- a/ext/http-parser/http_parser.c
+++ b/ext/http-parser/http_parser.c
@@ -1379,6 +1379,13 @@ reexecute:
                 parser->header_state = h_general;
               } else if (parser->index == sizeof(TRANSFER_ENCODING)-2) {
                 parser->header_state = h_transfer_encoding;
+
+                /* Multiple `Transfer-Encoding` headers should be treated as
+                 * one, but with values separate by a comma.
+                 *
+                 * See: https://tools.ietf.org/html/rfc7230#section-3.2.2
+                 */
+                parser->flags &= ~F_CHUNKED;
               }
               break;
 


### PR DESCRIPTION
Hi Development team,

I identified another vulnerability in a clone function http_parser_execute() in `ext/http-parser/http_parser.c` sourced from [nodejs/node](https://github.com/nodejs/node). These issues, originally reported in [CVE-2020-8287](https://nvd.nist.gov/vuln/detail/cve-2020-8287), were resolved in the node repository via this commit https://github.com/nodejs/node/commit/fc70ce08f5818a286fb5899a1bc3aff5965a745e.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase. Please review at your convenience. 

Additionally, I noticed that the file `ext/http-parser/http_parser.c` is missing some updates from recent commits in node repository. Please kindly verify and update if needed.

Thank you for your time and attention!