### PR TITLE
Don't count bridges towards multicast limit. Send to all bridges

### DIFF
--- a/node/Multicaster.cpp
+++ b/node/Multicaster.cpp
@@ -247,9 +247,6 @@ void Multicaster::send(void* tPtr, int64_t now, const SharedPtr<Network>& networ
 			for (unsigned int i = 0; i < activeBridgeCount; ++i) {
 				if ((activeBridges[i] != RR->identity.address()) && (activeBridges[i] != origin)) {
 					out.sendOnly(RR, tPtr, activeBridges[i]);	// optimization: don't use dedup log if it's a one-pass send
-					if (++count >= limit) {
-						break;
-					}
 				}
 			}
 


### PR DESCRIPTION
This makes it so that all bridges get multicast traffic and they do not count towards the normal multicast limit.