### PR TITLE
add 'apt update' to validation action

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -39,7 +39,7 @@ jobs:
         CXX: 'g++'
         BRANCH: ${{  github.ref_name }}
       run: |
-        sudo apt install -y valgrind xmlstarlet gcovr iperf3 tree
+        sudo apt update && sudo apt install -y valgrind xmlstarlet gcovr iperf3 tree
         make one ZT_COVERAGE=1 ZT_TRACE=1
         sudo chmod +x ./.github/workflows/validate-linux.sh
         sudo ./.github/workflows/validate-linux.sh


### PR DESCRIPTION
runs have started failing due to a stale package cache