### PR TITLE
Fix link select field in bond CLI

### DIFF
--- a/service/OneService.cpp
+++ b/service/OneService.cpp
@@ -662,6 +662,7 @@ static void _peerToJson(nlohmann::json& pj, const ZT_Peer* peer, SharedPtr<Bond>
 	if (bond && peer->isBonded) {
 		pj["bondingPolicyCode"] = peer->bondingPolicy;
 		pj["bondingPolicyStr"] = Bond::getPolicyStrByCode(peer->bondingPolicy);
+		pj["linkSelectMethod"] = bond->getLinkSelectMethod();
 		pj["numAliveLinks"] = peer->numAliveLinks;
 		pj["numTotalLinks"] = peer->numTotalLinks;
 		pj["failoverInterval"] = bond->getFailoverInterval();


### PR DESCRIPTION
This makes the active backup link select parameter show up in `zerotier-cli bond ___ show`. Previously it always showed 0.

```
Bond                   : active-backup
Link Select Method     : 3
```