### PR TITLE
Fix storing interface names

### DIFF
--- a/osdep/Binder.hpp
+++ b/osdep/Binder.hpp
@@ -470,6 +470,7 @@ class Binder {
 					if (_bindingCount < ZT_BINDER_MAX_BINDINGS) {
 						_bindings[_bindingCount].udpSock = udps;
 						_bindings[_bindingCount].address = ii->first;
+						memset(_bindings[_bindingCount].ifname, 0x0, ZT_MAX_PHYSIFNAME);
 						memcpy(_bindings[_bindingCount].ifname, (char*)ii->second.c_str(), (int)ii->second.length());
 						++_bindingCount;
 					}


### PR DESCRIPTION
This ensures interface names copied to the buffer are not corrupted by previous interface names in the buffer.

For instance, interface `wwan0` would be copied to the buffer, but a previous interface name stored would corrupt the interface name as seen below in the following logs:

```
attempting to nominate link ____-wwan0satellite
link ____-wwan0satellite is not allowed according to user-specified rules
```

This resulted in `zerotier-cli bond ___ show` reporting blank interface names and 0 quality scores.
```
idx                  interface                                  path               socket             local port
------------------------------------------------------------------------------------------------------------------------
...
 9:                                                           __________________________________            0
10:                                                          __________________________________            0
11:                                                           __________________________________            0
12:                                                           __________________________________            0
13:                                                           __________________________________            0
14:                                                            __________________________________            0
15:                                                           __________________________________            0
16:                                                           __________________________________            0
17:                                                            __________________________________            0

idx     lat      pdv    capacity    qual      rx_age      tx_age  eligible  bonded   flows
------------------------------------------------------------------------------------------------------------------------
...
 9:     0.00     0.00          0  0.0000         198         362         0       0       0
10:     0.00     0.00          0  0.0000         362         362         0       0       0
11:     0.00     0.00          0  0.0000         201         366         0       0       0
12:     0.00     0.00          0  0.0000         201         362         0       0       0
13:     0.00     0.00          0  0.0000         366         366         0       0       0
14:     0.00     0.00          0  0.0000         197         197         0       0       0
15:     0.00     0.00          0  0.0000         201         201         0       0       0
16:     0.00     0.00          0  0.0000         201         201         0       0       0
17:     0.00     0.00          0  0.0000         362         362         0       0       0
```