### PR TITLE
fix: standardize bond link selection method JSON field naming

### DIFF
--- a/service/OneService.cpp
+++ b/service/OneService.cpp
@@ -2612,7 +2612,17 @@ class OneServiceImpl : public OneService {
 					}
 					_node->bondController()->addCustomLink(customPolicyStr, new Link(linkNameStr, ipvPref, mtu, capacity, enabled, linkMode, failoverToStr));
 				}
-				std::string linkSelectMethodStr(OSUtils::jsonString(customPolicy["activeReselect"], "always"));
+				// Check for new field name first, fall back to legacy field name for backward compatibility
+				std::string linkSelectMethodStr;
+				if (customPolicy.contains("linkSelectMethod")) {
+					linkSelectMethodStr = OSUtils::jsonString(customPolicy["linkSelectMethod"], "always");
+				} else {
+					linkSelectMethodStr = OSUtils::jsonString(customPolicy["activeReselect"], "always");
+					if (customPolicy.contains("activeReselect")) {
+						fprintf(stderr, "warning: 'activeReselect' is deprecated, please use 'linkSelectMethod' instead in policy '%s'\n", customPolicyStr.c_str());
+					}
+				}
+				
 				if (linkSelectMethodStr == "always") {
 					newTemplateBond->setLinkSelectMethod(ZT_BOND_RESELECTION_POLICY_ALWAYS);
 				}


### PR DESCRIPTION
Adds support for "linkSelectMethod" as the JSON configuration field name while maintaining backward compatibility with the legacy "activeReselect" field name.

This change aligns the JSON field name with the internal API naming convention (setLinkSelectMethod/getLinkSelectMethod) and follows the established pattern in the codebase where JSON field names match their corresponding setter method names.

The implementation:
- Checks for the new field name first, then falls back to the legacy name
- Emits a deprecation warning when "activeReselect" is used
- Ensures existing configurations continue to work without modification

Resolves terminology inconsistency identified in docs PR [#263](https://github.com/zerotier/docs/pull/263)

🤖 Generated with [Claude Code](https://claude.ai/code)