### PR TITLE
Add a warning about missing DNS functionality on Linux

### DIFF
--- a/osdep/LinuxEthernetTap.hpp
+++ b/osdep/LinuxEthernetTap.hpp
@@ -59,6 +59,7 @@ class LinuxEthernetTap : public EthernetTap {
 	virtual void setMtu(unsigned int mtu);
 	virtual void setDns(const char* domain, const std::vector<InetAddress>& servers)
 	{
+		fprintf(stderr, "WARNING: ignoring call to LinuxEthernetTap::setDns on Linux. This is not implemented yet. See https://github.com/zerotier/ZeroTierOne/issues/2492 for details" ZT_EOL_S);
 	}
 
   private:


### PR DESCRIPTION
It took me quite some searching before I found out that this simply is not implemented. A warning would have been very useful.

refs: https://github.com/zerotier/ZeroTierOne/issues/2492