### PR TITLE
Ensure members in PacketMultiplexer are initialized

### DIFF
--- a/node/PacketMultiplexer.hpp
+++ b/node/PacketMultiplexer.hpp
@@ -44,15 +44,14 @@ class PacketMultiplexer {
 
 	std::vector<BlockingQueue<PacketRecord*>*> _rxPacketQueues;
 
-	unsigned int _concurrency;
+	unsigned int _concurrency = 0;
 	// pool
 	std::vector<PacketRecord*> _rxPacketVector;
 	std::vector<std::thread> _rxPacketThreads;
 	Mutex _rxPacketVector_m, _rxPacketThreads_m;
 
 	std::vector<std::thread> _rxThreads;
-	unsigned int _rxThreadCount;
-	bool _enabled;
+	bool _enabled = false;
 };
 
 }	// namespace ZeroTier


### PR DESCRIPTION
_enabled is set to true by setUpPostDecodeReceiveThreads(), so disabled until then, but the constructor wasn't initializing it. _concurrency is not being used before being set but for safety's sake, ensure it has a starting value as well.

Also, remove the vestigial _rxThreadCount, which is no longer used.