### PR TITLE
Fix bugs during program shutdown

### DIFF
--- a/osdep/Phy.hpp
+++ b/osdep/Phy.hpp
@@ -207,6 +207,7 @@ template <typename HANDLER_PTR_TYPE> class Phy {
 		_whackSendSocket = pipes[1];
 		_noDelay = noDelay;
 		_noCheck = noCheck;
+		FD_SET(_whackReceiveSocket, &_readfds);
 	}
 
 	~Phy()

--- a/service/OneService.cpp
+++ b/service/OneService.cpp
@@ -1014,12 +1014,12 @@ class OneServiceImpl : public OneService {
 		curl_global_cleanup();
 #endif
 
-		_controlPlane.stop();
 		if (_serverThreadRunning) {
+			_controlPlane.stop();
 			_serverThread.join();
 		}
-		_controlPlaneV6.stop();
 		if (_serverThreadRunningV6) {
+			_controlPlaneV6.stop();
 			_serverThreadV6.join();
 		}
 		_rxPacketVector_m.lock();


### PR DESCRIPTION
This PR fixes two issues that may occur during program shutdown.

1. `Phy::whack()` is intended to be called from another thread to abort `poll()`. However, I found that `_whackReceiveSocket` is not added to `_readfds` via `FD_SET`. As a result, `Phy::whack()` has no actual effect, and the program may block in the `select()` call during shutdown.

2. In `OneServiceImpl`, `_serverThreadRunning` / `_serverThreadRunningV6` are used to decide whether to join the HTTPControlPlane threads (`_serverThread` / `_serverThreadV6`). However, these flags are not thread-safe. When the program is about to exit, after calling `_controlPlane.stop()` / `_controlPlaneV6.stop()`, `_serverThreadRunning` / `_serverThreadRunningV6` may immediately become `false`, causing `_serverThread` / `_serverThreadV6` not to be joined. This can lead to the log message `terminate called without an active exception` and the program exiting with code 134.

The two commits in this PR fix the issues described above respectively.