### PR TITLE
Fix natpmp request issue on Windows

### DIFF
--- a/ext/libnatpmp/natpmp.c
+++ b/ext/libnatpmp/natpmp.c
@@ -39,12 +39,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <io.h>
-#ifndef EWOULDBLOCK
 #define EWOULDBLOCK WSAEWOULDBLOCK
-#endif
-#ifndef ECONNREFUSED
 #define ECONNREFUSED WSAECONNREFUSED
-#endif
 #include "wingettimeofday.h"
 #define gettimeofday natpmp_gettimeofday
 #else


### PR DESCRIPTION
When compiling ZeroTierOne with `MSVC140`, the `EWOULDBLOCK` macro is defined as `140` in `errno.h` by default, while `WSAEWOULDBLOCK` is defined as `10035` in `winsock2.h`. According to the current code, `EWOULDBLOCK` ultimately resolves to `140`. When `WSAGetLastError()` is used later, the timeout return value is `10035`, so it is not handled correctly by the existing logic.

https://github.com/zerotier/ZeroTierOne/blob/8d4cb1e05b96a169d596124e50dc3043908b4e19/ext/libnatpmp/natpmp.c#L214-L228

As a result, when ZeroTierOne encounters an intermittent timeout from the NAT-PMP service, it immediately tries the next `tryPort` instead of continuing to retry on the current `tryPort` for up to 10 seconds as expected.

https://github.com/zerotier/ZeroTierOne/blob/8d4cb1e05b96a169d596124e50dc3043908b4e19/osdep/PortMapper.cpp#L152-L164

This PR redefines `EWOULDBLOCK` to `WSAEWOULDBLOCK` (i.e., `10035`) so that ZeroTierOne can correctly handle NAT-PMP service timeout events.