### PR TITLE
WIP: Implement Linux DNS support via systemd-resolved

### DIFF
--- a/ext/installfiles/linux/zerotier-one-dns.rules
+++ b/ext/installfiles/linux/zerotier-one-dns.rules
@@ -1,0 +1,13 @@
+// Allow the zerotier-one service user to configure per-interface DNS
+// via systemd-resolved. Required because zerotier-one drops root
+// privileges to the zerotier-one user while retaining network
+// capabilities, but systemd-resolved checks polkit (not capabilities)
+// for DNS configuration changes.
+polkit.addRule(function(action, subject) {
+    if ((action.id == "org.freedesktop.resolve1.set-dns-servers" ||
+         action.id == "org.freedesktop.resolve1.set-domains" ||
+         action.id == "org.freedesktop.resolve1.revert") &&
+        subject.user == "zerotier-one") {
+        return polkit.Result.YES;
+    }
+});

--- a/make-linux.mk
+++ b/make-linux.mk
@@ -28,6 +28,7 @@ ifeq ($(ZT_EXTOSDEP),1)
 	ONE_OBJS+=osdep/ExtOsdep.o
 	override DEFS += -DZT_EXTOSDEP
 else
+	ONE_OBJS+=osdep/LinuxDNSHelper.o
 	ONE_OBJS+=osdep/LinuxEthernetTap.o
 	ONE_OBJS+=osdep/LinuxNetLink.o
 endif

--- a/osdep/LinuxDNSHelper.cpp
+++ b/osdep/LinuxDNSHelper.cpp
@@ -1,0 +1,115 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * (c) ZeroTier, Inc.
+ * https://www.zerotier.com/
+ */
+
+#ifdef __linux__
+
+#include "LinuxDNSHelper.hpp"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace ZeroTier {
+
+bool LinuxDNSHelper::isSystemdResolved()
+{
+	struct stat sb;
+	return (::stat("/run/systemd/resolve/stub-resolv.conf", &sb) == 0);
+}
+
+int LinuxDNSHelper::runResolvectl(const std::vector<std::string>& args)
+{
+	long p = (long)::fork();
+	if (p > 0) {
+		int exitcode = -1;
+		::waitpid(p, &exitcode, 0);
+		return WIFEXITED(exitcode) ? WEXITSTATUS(exitcode) : -1;
+	}
+	else if (p == 0) {
+		::close(STDOUT_FILENO);
+		::close(STDERR_FILENO);
+		std::vector<const char*> argv;
+		argv.push_back("resolvectl");
+		for (size_t i = 0; i < args.size(); ++i) {
+			argv.push_back(args[i].c_str());
+		}
+		argv.push_back(nullptr);
+		::execvp("resolvectl", const_cast<char* const*>(argv.data()));
+		::_exit(-1);
+	}
+	return -1;
+}
+
+void LinuxDNSHelper::setDNS(const char* interfaceName, const char* domain, const std::vector<InetAddress>& servers)
+{
+	if (! isSystemdResolved()) {
+		fprintf(
+			stderr,
+			"WARNING: systemd-resolved not detected. DNS configuration for ZeroTier networks requires systemd-resolved or manual configuration. "
+			"See https://github.com/zerotier/ZeroTierOne/issues/2492 for details" ZT_EOL_S);
+		return;
+	}
+
+	if (! interfaceName || ! interfaceName[0] || servers.empty()) {
+		return;
+	}
+
+	// resolvectl dns <interface> <ip1> <ip2> ...
+	{
+		std::vector<std::string> args;
+		args.push_back("dns");
+		args.push_back(interfaceName);
+		for (size_t i = 0; i < servers.size(); ++i) {
+			char buf[64];
+			args.push_back(servers[i].toIpString(buf));
+		}
+		int rc = runResolvectl(args);
+		if (rc != 0) {
+			fprintf(stderr, "WARNING: resolvectl dns failed (exit %d) for interface %s" ZT_EOL_S, rc, interfaceName);
+			return;
+		}
+	}
+
+	// resolvectl domain <interface> ~<domain>
+	if (domain && domain[0]) {
+		std::vector<std::string> args;
+		args.push_back("domain");
+		args.push_back(interfaceName);
+		args.push_back(std::string("~") + domain);
+		int rc = runResolvectl(args);
+		if (rc != 0) {
+			fprintf(stderr, "WARNING: resolvectl domain failed (exit %d) for interface %s" ZT_EOL_S, rc, interfaceName);
+		}
+	}
+}
+
+void LinuxDNSHelper::removeDNS(const char* interfaceName)
+{
+	if (! isSystemdResolved()) {
+		return;
+	}
+
+	if (! interfaceName || ! interfaceName[0]) {
+		return;
+	}
+
+	std::vector<std::string> args;
+	args.push_back("revert");
+	args.push_back(interfaceName);
+	int rc = runResolvectl(args);
+	if (rc != 0) {
+		fprintf(stderr, "WARNING: resolvectl revert failed (exit %d) for interface %s" ZT_EOL_S, rc, interfaceName);
+	}
+}
+
+}	// namespace ZeroTier
+
+#endif

--- a/osdep/LinuxDNSHelper.cpp
+++ b/osdep/LinuxDNSHelper.cpp
@@ -10,14 +10,69 @@
 
 #include "LinuxDNSHelper.hpp"
 
+#include <dirent.h>
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/prctl.h>
 #include <sys/stat.h>
+#include <sys/syscall.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <linux/capability.h>
+
+// Minimal PATH for subprocess execution, covering usr-merged and non-merged distros.
+#define ZT_SUBPROCESS_SAFE_PATH "/usr/bin:/bin:/usr/sbin:/sbin"
+
 namespace ZeroTier {
+
+namespace {
+
+// Same struct layout as one.cpp — avoids pulling in libcap
+struct _zt_cap_header_struct {
+	__u32 version;
+	int pid;
+};
+struct _zt_cap_data_struct {
+	__u32 effective;
+	__u32 permitted;
+	__u32 inheritable;
+};
+
+static void _dropAllCapabilities()
+{
+	::prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0);
+	_zt_cap_header_struct hdr = { _LINUX_CAPABILITY_VERSION_1, 0 };
+	_zt_cap_data_struct data = { 0, 0, 0 };
+	::syscall(SYS_capset, &hdr, &data);
+}
+
+static void _closeExtraFDs(int minFd)
+{
+	// close_range() syscall directly for portability with older glibc.
+#ifdef SYS_close_range
+	if (::syscall(SYS_close_range, (unsigned int)minFd, ~0U, 0) == 0)
+		return;
+#endif
+	// Fallback: iterate /proc/self/fd (always available on systemd systems)
+	DIR* d = ::opendir("/proc/self/fd");
+	if (!d)
+		return;
+	int dirfd_val = ::dirfd(d);
+	struct dirent* de;
+	while ((de = ::readdir(d)) != nullptr) {
+		if (de->d_name[0] == '.')
+			continue;
+		int fd = ::atoi(de->d_name);
+		if (fd >= minFd && fd != dirfd_val)
+			::close(fd);
+	}
+	::closedir(d);
+}
+
+}	// anonymous namespace
 
 bool LinuxDNSHelper::isSystemdResolved()
 {
@@ -34,8 +89,14 @@ int LinuxDNSHelper::runResolvectl(const std::vector<std::string>& args)
 		return WIFEXITED(exitcode) ? WEXITSTATUS(exitcode) : -1;
 	}
 	else if (p == 0) {
-		::close(STDOUT_FILENO);
-		::close(STDERR_FILENO);
+		_dropAllCapabilities();
+		_closeExtraFDs(STDOUT_FILENO);
+
+		// resolvectl only needs D-Bus access to systemd-resolved; a minimal
+		// environment with a safe PATH is sufficient.
+		::clearenv();
+		::setenv("PATH", ZT_SUBPROCESS_SAFE_PATH, 1);
+
 		std::vector<const char*> argv;
 		argv.push_back("resolvectl");
 		for (size_t i = 0; i < args.size(); ++i) {

--- a/osdep/LinuxDNSHelper.hpp
+++ b/osdep/LinuxDNSHelper.hpp
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * (c) ZeroTier, Inc.
+ * https://www.zerotier.com/
+ */
+
+#ifndef LINUX_DNS_HELPER_H_
+#define LINUX_DNS_HELPER_H_
+
+#include "../node/InetAddress.hpp"
+
+#include <string>
+#include <vector>
+
+namespace ZeroTier {
+
+class LinuxDNSHelper {
+  public:
+	static void setDNS(const char* interfaceName, const char* domain, const std::vector<InetAddress>& servers);
+	static void removeDNS(const char* interfaceName);
+
+  private:
+	static bool isSystemdResolved();
+	static int runResolvectl(const std::vector<std::string>& args);
+};
+
+}	// namespace ZeroTier
+
+#endif

--- a/osdep/LinuxEthernetTap.cpp
+++ b/osdep/LinuxEthernetTap.cpp
@@ -17,6 +17,7 @@
 #include "../node/Dictionary.hpp"
 #include "../node/Mutex.hpp"
 #include "../node/Utils.hpp"
+#include "LinuxDNSHelper.hpp"
 #include "LinuxEthernetTap.hpp"
 #include "LinuxNetLink.hpp"
 #include "OSUtils.hpp"
@@ -358,6 +359,7 @@ LinuxEthernetTap::LinuxEthernetTap(
 LinuxEthernetTap::~LinuxEthernetTap()
 {
 	_run = false;
+	LinuxDNSHelper::removeDNS(_dev.c_str());
 	(void)::write(_shutdownSignalPipe[1], "\0", 1);
 	::close(_fd);
 	::close(_shutdownSignalPipe[0]);
@@ -587,6 +589,11 @@ void LinuxEthernetTap::setMtu(unsigned int mtu)
 			close(sock);
 		}
 	}
+}
+
+void LinuxEthernetTap::setDns(const char* domain, const std::vector<InetAddress>& servers)
+{
+	LinuxDNSHelper::setDNS(_dev.c_str(), domain, servers);
 }
 
 }	// namespace ZeroTier

--- a/osdep/LinuxEthernetTap.hpp
+++ b/osdep/LinuxEthernetTap.hpp
@@ -52,10 +52,7 @@ class LinuxEthernetTap : public EthernetTap {
 	virtual void setFriendlyName(const char* friendlyName);
 	virtual void scanMulticastGroups(std::vector<MulticastGroup>& added, std::vector<MulticastGroup>& removed);
 	virtual void setMtu(unsigned int mtu);
-	virtual void setDns(const char* domain, const std::vector<InetAddress>& servers)
-	{
-		fprintf(stderr, "WARNING: ignoring call to LinuxEthernetTap::setDns on Linux. This is not implemented yet. See https://github.com/zerotier/ZeroTierOne/issues/2492 for details" ZT_EOL_S);
-	}
+	virtual void setDns(const char* domain, const std::vector<InetAddress>& servers);
 
   private:
 	void (*_handler)(void*, void*, uint64_t, const MAC&, const MAC&, unsigned int, unsigned int, const void*, unsigned int);

--- a/service/OneService.cpp
+++ b/service/OneService.cpp
@@ -111,6 +111,8 @@ namespace sdkresource = opentelemetry::v1::sdk::resource;
 #elif defined(__WINDOWS__)
 #include "../osdep/WinDNSHelper.hpp"
 #include "../osdep/WinFWHelper.hpp"
+#elif defined(__linux__)
+#include "../osdep/LinuxDNSHelper.hpp"
 #endif
 
 #ifdef ZT_USE_SYSTEM_HTTP_PARSER
@@ -3577,6 +3579,10 @@ class OneServiceImpl : public OneService {
 				MacDNSHelper::removeDNS(n.config().nwid);
 #elif defined(__WINDOWS__)
 				WinDNSHelper::removeDNS(n.config().nwid);
+#elif defined(__linux__)
+				if (n.tap()) {
+					LinuxDNSHelper::removeDNS(n.tap()->deviceName().c_str());
+				}
 #endif
 			}
 		}

--- a/zerotier-one.spec
+++ b/zerotier-one.spec
@@ -118,6 +118,8 @@ make ZT_USE_MINIUPNPC=1 %{?_smp_mflags} ZT_OFFICIAL=1 ZT_NONFREE=1 one
 make install DESTDIR=$RPM_BUILD_ROOT
 mkdir -p $RPM_BUILD_ROOT%{_unitdir}
 cp %{getenv:PWD}/debian/zerotier-one.service $RPM_BUILD_ROOT%{_unitdir}/%{name}.service
+mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/polkit-1/rules.d
+cp %{getenv:PWD}/ext/installfiles/linux/zerotier-one-dns.rules $RPM_BUILD_ROOT%{_sysconfdir}/polkit-1/rules.d/49-zerotier-one-dns.rules
 %else
 rm -rf $RPM_BUILD_ROOT
 pushd %{getenv:PWD}
@@ -137,6 +139,7 @@ chmod 0755 $RPM_BUILD_ROOT/etc/init.d/zerotier-one
 /etc/init.d/zerotier-one
 %else
 %{_unitdir}/%{name}.service
+%{_sysconfdir}/polkit-1/rules.d/49-zerotier-one-dns.rules
 %endif
 
 %post


### PR DESCRIPTION
Implements `LinuxEthernetTap::setDns`. The `allowDNS` network flag now works on Linux, matching existing Windows and macOS behavior.

This partially addresses #2492 , though has only been tested on Fedora 43. The polkit approach may need to be fixed for Debian/Ubuntu.

# Approach

- New `LinuxDNSHelper` class following the same pattern as `WinDNSHelper` and `MacDNSHelper`
- Calls `resolvectl dns <iface> <servers>` and `resolvectl domain <iface> ~<domain>` to configure per-interface DNS routing via `systemd-resolved`, the recommended approach for VPN-like services
- The `~` domain prefix configures a *route-only* domain (not a search domain), so queries matching that suffix are routed to the ZT DNS servers without polluting global resolution
- Cleanup via `resolvectl revert <iface>` in the destructor and when `allowDNS` is toggled off
- Subprocess spawning uses `fork`/`exec` matching the existing `_routeCmd` pattern in `ManagedRoute.cpp`

## Non-systemd systems

Checks for `/run/systemd/resolve/stub-resolv.conf` before attempting any `resolvectl` calls. If `systemd-resolved` is not active, `setDNS` logs a warning pointing to #2492 and returns.

## polkit rule

**(This was developed for Fedora, I'm not sure of the Debian/Ubuntu situation here)**

ZeroTier drops root privileges to the `zerotier-one` user at startup (retaining `CAP_NET_ADMIN`/`CAP_NET_RAW`). However, `systemd-resolved` checks polkit identity — not capabilities — for DNS changes. A polkit rule is included and installed by the RPM spec to grant the `zerotier-one` user access to `org.freedesktop.resolve1.{set-dns-servers,set-domains,revert}`.

## Interface name vs network ID

Unlike Windows/macOS helpers which take a network ID, `LinuxDNSHelper` takes an interface name because `resolvectl` operates on interfaces.

----

*This PR was created with help from Claude.*