### PR TITLE
Fix RPM build on Fedora 42+ (sbin merge)

### DIFF
--- a/make-linux.mk
+++ b/make-linux.mk
@@ -13,6 +13,7 @@ INCLUDES?=-Irustybits/target -isystem ext -Iext/prometheus-cpp-lite-1.0/core/inc
 DEFS?=
 LDLIBS?=
 DESTDIR?=
+SBINDIR?=$(DESTDIR)/usr/sbin
 EXTRA_DEPS?=
 
 include objects.mk
@@ -501,13 +502,13 @@ endif
 # lived here. Folks got scripts.
 
 install:	FORCE
-	mkdir -p $(DESTDIR)/usr/sbin
-	rm -f $(DESTDIR)/usr/sbin/zerotier-one
-	cp -f zerotier-one $(DESTDIR)/usr/sbin/zerotier-one
-	rm -f $(DESTDIR)/usr/sbin/zerotier-cli
-	rm -f $(DESTDIR)/usr/sbin/zerotier-idtool
-	ln -s zerotier-one $(DESTDIR)/usr/sbin/zerotier-cli
-	ln -s zerotier-one $(DESTDIR)/usr/sbin/zerotier-idtool
+	mkdir -p $(SBINDIR)
+	rm -f $(SBINDIR)/zerotier-one
+	cp -f zerotier-one $(SBINDIR)/zerotier-one
+	rm -f $(SBINDIR)/zerotier-cli
+	rm -f $(SBINDIR)/zerotier-idtool
+	ln -s zerotier-one $(SBINDIR)/zerotier-cli
+	ln -s zerotier-one $(SBINDIR)/zerotier-idtool
 	mkdir -p $(DESTDIR)/var/lib/zerotier-one
 	rm -f $(DESTDIR)/var/lib/zerotier-one/zerotier-one
 	rm -f $(DESTDIR)/var/lib/zerotier-one/zerotier-cli
@@ -532,9 +533,9 @@ uninstall:	FORCE
 	rm -f $(DESTDIR)/var/lib/zerotier-one/zerotier-one
 	rm -f $(DESTDIR)/var/lib/zerotier-one/zerotier-cli
 	rm -f $(DESTDIR)/var/lib/zerotier-one/zerotier-idtool
-	rm -f $(DESTDIR)/usr/sbin/zerotier-cli
-	rm -f $(DESTDIR)/usr/sbin/zerotier-idtool
-	rm -f $(DESTDIR)/usr/sbin/zerotier-one
+	rm -f $(SBINDIR)/zerotier-cli
+	rm -f $(SBINDIR)/zerotier-idtool
+	rm -f $(SBINDIR)/zerotier-one
 	rm -rf $(DESTDIR)/var/lib/zerotier-one/iddb.d
 	rm -rf $(DESTDIR)/var/lib/zerotier-one/updates.d
 	rm -rf $(DESTDIR)/var/lib/zerotier-one/networks.d

--- a/zerotier-one.spec
+++ b/zerotier-one.spec
@@ -115,13 +115,13 @@ make ZT_USE_MINIUPNPC=1 %{?_smp_mflags} ZT_OFFICIAL=1 ZT_NONFREE=1 one
 
 %install
 %if "%{?dist}" != ".el6"
-make install DESTDIR=$RPM_BUILD_ROOT
+make install DESTDIR=$RPM_BUILD_ROOT SBINDIR=$RPM_BUILD_ROOT%{_sbindir}
 mkdir -p $RPM_BUILD_ROOT%{_unitdir}
 cp %{getenv:PWD}/debian/zerotier-one.service $RPM_BUILD_ROOT%{_unitdir}/%{name}.service
 %else
 rm -rf $RPM_BUILD_ROOT
 pushd %{getenv:PWD}
-make install DESTDIR=$RPM_BUILD_ROOT
+make install DESTDIR=$RPM_BUILD_ROOT SBINDIR=$RPM_BUILD_ROOT%{_sbindir}
 popd
 mkdir -p $RPM_BUILD_ROOT/etc/init.d
 cp %{getenv:PWD}/ext/installfiles/linux/zerotier-one.init.rhel6 $RPM_BUILD_ROOT/etc/init.d/zerotier-one


### PR DESCRIPTION
## Summary

RPM builds fail on Fedora 42+ with `File not found: .../BUILDROOT/usr/bin/*` because the [Unify /usr/bin and /usr/sbin](https://fedoraproject.org/wiki/Changes/Unify_bin_and_sbin) change made `/usr/sbin` a symlink to `/usr/bin`, so `%{_sbindir}` now expands to `/usr/bin`. The Makefile's `install` target hardcodes `/usr/sbin`, creating a real directory in the BUILDROOT that doesn't match what RPM expects.

## Changes

- **`make-linux.mk`**: Add configurable `SBINDIR` variable (defaults to `$(DESTDIR)/usr/sbin`), replacing hardcoded paths in `install` and `uninstall` targets. Default behavior on non-RPM systems is unchanged.
- **`zerotier-one.spec`**: Pass `SBINDIR=$RPM_BUILD_ROOT%{_sbindir}` to `make install` so binaries land where the `%files` section expects them.

## Backward compatibility

- `SBINDIR` defaults to `$(DESTDIR)/usr/sbin` — existing `make install` workflows, Debian packaging, and older RHEL/CentOS builds are unaffected.
- `/var/lib/zerotier-one` symlinks still point to `../../../usr/sbin/zerotier-one` which resolves correctly on both merged and unmerged systems.

----
*This PR was created with help from Claude.*