### PR TITLE
Refactor manpages build script and rebuild shipped files

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -3,4 +3,4 @@ Manual Pages and Other Documentation
 
 Use "./build.sh" to build the manual pages.
 
-You'll need either Node.js/npm installed (script will then automatically install the npm *marked-man* package) or */usr/bin/ronn*. The latter is a Ruby program packaged on some distributions as *rubygem-ronn* or *ruby-ronn* or installable as *gem install ronn*. The Node *marked-man* package and *ronn* from RubyGems are two roughly equivalent alternatives for compiling Markdown into roff/man format.
+You'll need either Node.js/npm installed (script will then automatically install the npm *marked-man* package) or *ronn*. The latter is a Ruby program packaged on some distributions as *rubygem-ronn* or *ruby-ronn* or installable as *gem install ronn*. The Node *marked-man* package and *ronn* from RubyGems are two roughly equivalent alternatives for compiling Markdown into roff/man format.

--- a/doc/build.sh
+++ b/doc/build.sh
@@ -1,42 +1,49 @@
 #!/bin/bash
 
-export PATH=/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin
-
 if [ ! -f zerotier-cli.1.md ]; then
-	echo 'This script must be run from the doc/ subfolder of the ZeroTier tree.'
+    echo 'This script must be run from the doc/ subfolder of the ZeroTier tree.'
 fi
+
+ronn_build() {
+    echo "Using ronn"
+
+    ronn -r zerotier-cli.1.md
+    ronn -r zerotier-idtool.1.md
+    ronn -r zerotier-one.8.md
+}
+
+marked_man_build() {
+	NODE="$1"
+    MARKED_MAN="node_modules/marked-man/bin/marked-man"
+
+    echo "Using marked-man"
+
+    if [ ! -f "$MARKED_MAN.js" ]; then
+		echo 'Installing npm package "marked-man" -- MarkDown to ROFF converter...'
+        npm install marked-man
+	fi
+
+    $NODE "$MARKED_MAN" zerotier-cli.1.md > zerotier-cli.1
+    $NODE "$MARKED_MAN" zerotier-idtool.1.md > zerotier-idtool.1
+	$NODE "$MARKED_MAN" zerotier-one.8.md > zerotier-one.8
+}
+
+command_exists() {
+    type "$1" > /dev/null 2>&1
+}
 
 rm -f *.1 *.2 *.8
+echo "Building man pages..."
 
-if [ -e /usr/bin/ronn -o -e /usr/local/bin/ronn ]; then
-	# Use 'ronn' which is available as a package on many distros including Debian
-	ronn -r zerotier-cli.1.md
-	ronn -r zerotier-idtool.1.md
-	ronn -r zerotier-one.8.md
+# Use 'ronn' which is available as a package on many distros including Debian
+if command_exists "ronn"; then
+	ronn_build
+# Use 'marked-man' from npm
+elif command_exists "node"; then
+	marked_man_build "node"
+elif command_exists "nodejs"; then
+    marked_man_build "nodejs"
 else
-	# Use 'marked-man' from npm
-	NODE=/usr/bin/node
-	if [ ! -e $NODE ]; then
-		if [ -e /usr/bin/nodejs ]; then
-			NODE=/usr/bin/nodejs
-		elif [ -e /usr/local/bin/node ]; then
-			NODE=/usr/local/bin/node
-		elif [ -e /usr/local/bin/nodejs ]; then
-			NODE=/usr/local/bin/nodejs
-		else
-			echo 'Unable to find ronn or node/npm -- cannot build man pages!'
-			exit 1
-		fi
-	fi
-
-	if [ ! -f node_modules/marked-man/bin/marked-man ]; then
-		echo 'Installing npm package "marked-man" -- MarkDown to ROFF converter...'
-		npm install marked-man
-	fi
-
-	$NODE node_modules/marked-man/bin/marked-man zerotier-cli.1.md >zerotier-cli.1
-	$NODE node_modules/marked-man/bin/marked-man zerotier-idtool.1.md >zerotier-idtool.1
-	$NODE node_modules/marked-man/bin/marked-man zerotier-one.8.md >zerotier-one.8
+    echo 'Unable to find ronn or node/npm -- cannot build man pages!'
+	exit 1
 fi
-
-exit 0

--- a/doc/zerotier-cli.1
+++ b/doc/zerotier-cli.1
@@ -1,55 +1,49 @@
-.TH "ZEROTIER\-CLI" "1" "December 2016" "" ""
+.\" generated with Ronn-NG/v0.10.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.10.1
+.TH "ZEROTIER\-CLI" "1" "April 2026" ""
 .SH "NAME"
-\fBzerotier-cli\fR \- control local ZeroTier virtual network service
-.SH SYNOPSIS
-.P
-\fBzerotier\-cli\fP [\-switches] <command> [arguments]
-.SH DESCRIPTION
-.P
+\fBzerotier\-cli\fR \- control local ZeroTier virtual network service
+.SH "SYNOPSIS"
+\fBzerotier\-cli\fR [\-switches] \fIcommand\fR [arguments]
+.SH "DESCRIPTION"
 \fBzerotier\-cli\fR provides a simple command line interface to the local JSON API of the ZeroTier virtual network endpoint service zerotier\-one(8)\.
 .P
-By default \fBzerotier\-cli\fR must be run as root or with \fBsudo\fP\|\. If you want to allow an unprivileged user to use \fBzerotier\-cli\fR to control the system ZeroTier service, you can create a local copy of the ZeroTier service authorization token in the user's home directory:
-.P
-.RS 2
+By default \fBzerotier\-cli\fR must be run as root or with \fBsudo\fR\. If you want to allow an unprivileged user to use \fBzerotier\-cli\fR to control the system ZeroTier service, you can create a local copy of the ZeroTier service authorization token in the user's home directory:
+.IP "" 4
 .nf
 sudo cp /var/lib/zerotier\-one/authtoken\.secret /home/user/\.zeroTierOneAuthToken
 chown user /home/user/\.zeroTierOneAuthToken
 chmod 0600 /home/user/\.zeroTierOneAuthToken
 .fi
-.RE
+.IP "" 0
 .P
 (The location of ZeroTier's service home may differ by platform\. See zerotier\-one(8)\.)
 .P
 Note that this gives the user the power to connect or disconnect the system to or from any virtual network, which is a significant permission\.
 .P
-\fBzerotier\-cli\fR has several command line arguments that are visible in \fBhelp\fP output\. The two most commonly used are \fB\-j\fP for raw JSON output and \fB\-D<path>\fP to specify an alternative ZeroTier service working directory\. Raw JSON output is easier to parse in scripts and also contains verbose details not present in the tabular output\. The \fB\-D<path>\fP option specifies where the service's zerotier\-one\.port and authtoken\.secret files are located if the service is not running at the default location for your system\.
-.SH COMMANDS
-.RS 0
-.IP \(bu 2
-\fBhelp\fP:
+\fBzerotier\-cli\fR has several command line arguments that are visible in \fBhelp\fR output\. The two most commonly used are \fB\-j\fR for raw JSON output and \fB\-D<path>\fR to specify an alternative ZeroTier service working directory\. Raw JSON output is easier to parse in scripts and also contains verbose details not present in the tabular output\. The \fB\-D<path>\fR option specifies where the service's zerotier\-one\.port and authtoken\.secret files are located if the service is not running at the default location for your system\.
+.SH "COMMANDS"
+.TP
+\fBhelp\fR
 Displays \fBzerotier\-cli\fR help\.
-.IP \(bu 2
-\fBinfo\fP:
-Shows information about this device including its 10\-digit ZeroTier address and apparent connection status\. Use \fB\-j\fP for more verbose output\.
-.IP \(bu 2
-\fBlistpeers\fP:
+.TP
+\fBinfo\fR
+Shows information about this device including its 10\-digit ZeroTier address and apparent connection status\. Use \fB\-j\fR for more verbose output\.
+.TP
+\fBlistpeers\fR
 This command lists the ZeroTier VL1 (virtual layer 1, the peer to peer network) peers this service knows about and has recently (within the past 30 minutes or so) communicated with\. These are not necessarily all the devices on your virtual network(s), and may also include a few devices not on any virtual network you've joined\. These are typically either root servers or network controllers\.
-.IP \(bu 2
-\fBlistnetworks\fP:
+.TP
+\fBlistnetworks\fR
 This lists the networks your system belongs to and some information about them, such as any ZeroTier\-managed IP addresses you have been assigned\. (IP addresses assigned manually to ZeroTier interfaces will not be listed here\. Use the standard network interface commands to see these\.)
-.IP \(bu 2
-\fBjoin\fP:
-To join a network just use \fBjoin\fP and its 16\-digit hex network ID\. That's it\. Then use \fBlistnetworks\fP to see the status\. You'll either get a reply from the network controller with a certificate and other info such as IP assignments, or you'll get "access denied\." In this case you'll need the administrator of this network to authorize your device by its 10\-digit device ID (visible with \fBinfo\fP) on the network's controller\.
-.IP \(bu 2
-\fBleave\fP:
-Leaving a network is as easy as joining it\. This disconnects from the network and deletes its interface from the system\. Note that peers on the network may hang around in \fBlistpeers\fP for up to 30 minutes until they time out due to lack of traffic\. But if they no longer share a network with you, they can't actually communicate with you in any meaningful way\.
-
-.RE
-.SH EXAMPLES
-.P
+.TP
+\fBjoin\fR
+To join a network just use \fBjoin\fR and its 16\-digit hex network ID\. That's it\. Then use \fBlistnetworks\fR to see the status\. You'll either get a reply from the network controller with a certificate and other info such as IP assignments, or you'll get "access denied\." In this case you'll need the administrator of this network to authorize your device by its 10\-digit device ID (visible with \fBinfo\fR) on the network's controller\.
+.TP
+\fBleave\fR
+Leaving a network is as easy as joining it\. This disconnects from the network and deletes its interface from the system\. Note that peers on the network may hang around in \fBlistpeers\fR for up to 30 minutes until they time out due to lack of traffic\. But if they no longer share a network with you, they can't actually communicate with you in any meaningful way\.
+.SH "EXAMPLES"
 Join "Earth," ZeroTier's big public party line network:
-.P
-.RS 2
+.IP "" 4
 .nf
 $ sudo zerotier\-cli join 8056c2e21c000001
 $ sudo zerotier\-cli listnetworks
@@ -57,27 +51,22 @@ $ sudo zerotier\-cli listnetworks
 $ ping earth\.zerotier\.net
 ( you should now be able to ping our Earth test IP )
 .fi
-.RE
+.IP "" 0
 .P
 Leave "Earth":
-.P
-.RS 2
+.IP "" 4
 .nf
 $ sudo zerotier\-cli leave 8056c2e21c000001
 .fi
-.RE
+.IP "" 0
 .P
 List VL1 peers:
-.P
-.RS 2
+.IP "" 4
 .nf
 $ sudo zerotier\-cli listpeers
 .fi
-.RE
-.SH COPYRIGHT
-.P
+.IP "" 0
+.SH "COPYRIGHT"
 (c)2011\-2016 ZeroTier, Inc\. \-\- https://www\.zerotier\.com/ \-\- https://github\.com/zerotier
-.SH SEE ALSO
-.P
+.SH "SEE ALSO"
 zerotier\-one(8), zerotier\-idtool(1)
-

--- a/doc/zerotier-idtool.1
+++ b/doc/zerotier-idtool.1
@@ -1,84 +1,71 @@
-.TH "ZEROTIER\-IDTOOL" "1" "December 2016" "" ""
+.\" generated with Ronn-NG/v0.10.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.10.1
+.TH "ZEROTIER\-IDTOOL" "1" "April 2026" ""
 .SH "NAME"
-\fBzerotier-idtool\fR \- tool for creating and manipulating ZeroTier identities
-.SH SYNOPSIS
-.P
-\fBzerotier\-idtool\fP <command> [args]
-.SH DESCRIPTION
-.P
+\fBzerotier\-idtool\fR \- tool for creating and manipulating ZeroTier identities
+.SH "SYNOPSIS"
+\fBzerotier\-idtool\fR \fIcommand\fR [args]
+.SH "DESCRIPTION"
 \fBzerotier\-idtool\fR is a command line utility for doing things with ZeroTier identities\. A ZeroTier identity consists of a public/private key pair (or just the public if it's only an identity\.public) and a 10\-digit hexadecimal ZeroTier address derived from the public key by way of a proof of work based hash function\.
-.SH COMMANDS
-.P
+.SH "COMMANDS"
 When command arguments call for a public or secret (full) identity, the identity can be specified as a path to a file or directly on the command line\.
-.RS 0
-.IP \(bu 2
-\fBhelp\fP:
+.TP
+\fBhelp\fR
 Display help\. (Also running with no command does this\.)
-.IP \(bu 2
-\fBgenerate\fP [secret file] [public file] [vanity]:
+.TP
+\fBgenerate\fR [secret file] [public file] [vanity]
 Generate a new ZeroTier identity\. If a secret file is specified, the full identity including the private key will be written to this file\. If the public file is specified, the public portion will be written there\. If no file paths are specified the full secret identity is output to STDOUT\. The vanity prefix is a series of hexadecimal digits that the generated identity's address should start with\. Typically this isn't used, and if it's specified generation can take a very long time due to the intrinsic cost of generating identities with their proof of work function\. Generating an identity with a known 16\-bit (4 digit) prefix on a 2\.8ghz Core i5 (using one core) takes an average of two hours\.
-.IP \(bu 2
-\fBvalidate\fP <identity, only public part required>:
+.TP
+\fBvalidate\fR \fIidentity, only public part required\fR
 Locally validate an identity's key and proof of work function correspondence\.
-.IP \(bu 2
-\fBgetpublic\fP <full identity with secret>:
+.TP
+\fBgetpublic\fR \fIfull identity with secret\fR
 Extract the public portion of an identity\.secret and print to STDOUT\.
-.IP \(bu 2
-\fBsign\fP <full identity with secret> <file to sign>:
+.TP
+\fBsign\fR \fIfull identity with secret\fR \fIfile to sign\fR
 Sign a file's contents with SHA512+ECC\-256 (ed25519)\. The signature is output in hex to STDOUT\.
-.IP \(bu 2
-\fBverify\fP <identity, only public part required> <file to check> <signature in hex>:
-Verify a signature created with \fBsign\fP\|\.
-.IP \(bu 2
-\fBmkcom\fP <full identity with secret> [id,value,maxdelta] [\|\.\.\.]:
+.TP
+\fBverify\fR \fIidentity, only public part required\fR \fIfile to check\fR \fIsignature in hex\fR
+Verify a signature created with \fBsign\fR\.
+.TP
+\fBmkcom\fR \fIfull identity with secret\fR [id,value,maxdelta] [\|\.\|\.\|\.]
 Create and sign a network membership certificate\. This is not generally useful since network controllers do this automatically and is included mostly for testing purposes\.
-
-.RE
-.SH EXAMPLES
-.P
+.SH "EXAMPLES"
 Generate and dump a new identity:
-.P
-.RS 2
+.IP "" 4
 .nf
 $ zerotier\-idtool generate
 .fi
-.RE
+.IP "" 0
 .P
 Generate and write a new identity, both secret and public parts:
-.P
-.RS 2
+.IP "" 4
 .nf
 $ zerotier\-idtool generate identity\.secret identity\.public
 .fi
-.RE
+.IP "" 0
 .P
 Generate a vanity address that begins with the hex digits "beef" (this will take a while!):
-.P
-.RS 2
+.IP "" 4
 .nf
 $ zerotier\-idtool generate beef\.secret beef\.public beef
 .fi
-.RE
+.IP "" 0
 .P
 Sign a file with an identity's secret key:
-.P
-.RS 2
+.IP "" 4
 .nf
 $ zerotier\-idtool sign identity\.secret last_will_and_testament\.txt
 .fi
-.RE
+.IP "" 0
 .P
 Verify a file's signature with a public key:
-.P
-.RS 2
+.IP "" 4
 .nf
 $ zerotier\-idtool verify identity\.public last_will_and_testament\.txt
 .fi
-.RE
-.SH COPYRIGHT
-.P
+.IP "" 0
+.SH "COPYRIGHT"
 (c)2011\-2016 ZeroTier, Inc\. \-\- https://www\.zerotier\.com/ \-\- https://github\.com/zerotier
-.SH SEE ALSO
-.P
+.SH "SEE ALSO"
 zerotier\-one(8), zerotier\-cli(1)
-

--- a/doc/zerotier-one.8
+++ b/doc/zerotier-one.8
@@ -1,104 +1,91 @@
-.TH "ZEROTIER\-ONE" "8" "December 2016" "" ""
+.\" generated with Ronn-NG/v0.10.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.10.1
+.TH "ZEROTIER\-ONE" "8" "April 2026" ""
 .SH "NAME"
-\fBzerotier-one\fR \- ZeroTier virtual network endpoint service
-.SH SYNOPSIS
-.P
-\fBzerotier\-one\fP [\-switches] [working directory]
-.SH DESCRIPTION
-.P
+\fBzerotier\-one\fR \- ZeroTier virtual network endpoint service
+.SH "SYNOPSIS"
+\fBzerotier\-one\fR [\-switches] [working directory]
+.SH "DESCRIPTION"
 \fBzerotier\-one\fR is the service/daemon responsible for connecting a Unix (Linux/BSD/OSX) system to one or more ZeroTier virtual networks and presenting those networks to the system as virtual network ports\. You can think of it as a peer to peer VPN client\.
 .P
-It's typically run by init systems like systemd (Linux) or launchd (Mac) rather than directly by the user, and it must be run as root unless you give it the \fB\-U\fP switch and don't plan on actually joining networks (e\.g\. to run a network controller microservice only)\.
+It's typically run by init systems like systemd (Linux) or launchd (Mac) rather than directly by the user, and it must be run as root unless you give it the \fB\-U\fR switch and don't plan on actually joining networks (e\.g\. to run a network controller microservice only)\.
 .P
 The \fBzerotier\-one\fR service keeps its state and other files in a working directory\. If this directory is not specified at launch it defaults to "/var/lib/zerotier\-one" on Linux, "/Library/Application Support/ZeroTier/One" on Mac, and "/var/db/zerotier\-one" on FreeBSD and other similar BSDs\. The working directory should persist\. It shouldn't be automatically cleaned by system cleanup daemons or stored in a volatile location\. Loss of its identity\.secret file results in loss of this system's unique 10\-digit ZeroTier address and key\.
 .P
 Multiple instances of \fBzerotier\-one\fR can be run on the same system as long as they are run with different primary ports (see switches) and a different working directory\. But since a single service can join any number of networks, typically there's no point in doing this\.
 .P
-The \fBzerotier\-one\fR service is controlled via a JSON API available at 127\.0\.0\.1:<primary port> with the default primary port being 9993\. Access to this API requires an authorization token normally found in the authtoken\.secret file in the service's working directory\. On some platforms access may be guarded by other measures such as socket peer UID/GID lookup if additional security options are enabled (this is not the default)\.
+The \fBzerotier\-one\fR service is controlled via a JSON API available at 127\.0\.0\.1:\fIprimary port\fR with the default primary port being 9993\. Access to this API requires an authorization token normally found in the authtoken\.secret file in the service's working directory\. On some platforms access may be guarded by other measures such as socket peer UID/GID lookup if additional security options are enabled (this is not the default)\.
 .P
 The first time the service is started in a fresh working directory, it generates a ZeroTier identity\. On slow systems this process can take ten seconds or more due to an anti\-DDOS/anti\-counterfeit proof of work function used by ZeroTier in address generation\. This only happens once, and once generated the result is saved in identity\.secret in the working directory\. This file represents and defines/claims your ZeroTier address and associated ECC\-256 key pair\.
-.SH SWITCHES
-.RS 0
-.IP \(bu 2
-\fB\-h\fP:
+.SH "SWITCHES"
+.TP
+\fB\-h\fR
 Display help\.
-.IP \(bu 2
-\fB\-v\fP:
+.TP
+\fB\-v\fR
 Display ZeroTier One version\.
-.IP \(bu 2
-\fB\-U\fP:
+.TP
+\fB\-U\fR
 Skip privilege check and allow to be run by non\-privileged user\. This is typically used when \fBzerotier\-one\fR is built with the network controller option included\. In this case the ZeroTier service might only be acting as a network controller and might never actually join networks, in which case it does not require elevated system permissions\.
-.IP \(bu 2
-\fB\-p<port>\fP:
+.TP
+\fB\-p<port>\fR
 Specify a different primary port\. If this is not given the default is 9993\. If zero is given a random port is chosen each time\.
-.IP \(bu 2
-\fB\-d\fP:
+.TP
+\fB\-d\fR
 Fork and run as a daemon\.
-.IP \(bu 2
-\fB\-i\fP:
+.TP
+\fB\-i\fR
 Invoke the \fBzerotier\-idtool\fR personality, in which case the binary behaves like zerotier\-idtool(1)\. This happens automatically if the name of the binary (or a symlink to it) is zerotier\-idtool\.
-.IP \(bu 2
-\fB\-q\fP:
+.TP
+\fB\-q\fR
 Invoke the \fBzerotier\-cli\fR personality, in which case the binary behaves like zerotier\-cli(1)\. This happens automatically if the name of the binary (or a symlink to it) is zerotier\-cli\.
-
-.RE
-.SH EXAMPLES
-.P
+.SH "EXAMPLES"
 Run as daemon with OS default working directory and default port:
-.P
-.RS 2
+.IP "" 4
 .nf
 $ sudo zerotier\-one \-d
 .fi
-.RE
+.IP "" 0
 .P
 Run as daemon with a different working directory and port:
-.P
-.RS 2
+.IP "" 4
 .nf
 $ sudo zerotier\-one \-d \-p12345 /tmp/zerotier\-working\-directory\-test
 .fi
-.RE
-.SH FILES
-.P
+.IP "" 0
+.SH "FILES"
 These are found in the service's working directory\.
-.RS 0
-.IP \(bu 2
-\fBidentity\.public\fP:
+.TP
+\fBidentity\.public\fR
 The public portion of your ZeroTier identity, which is your 10\-digit hex address and the associated public key\.
-.IP \(bu 2
-\fBidentity\.secret\fP:
+.TP
+\fBidentity\.secret\fR
 Your full ZeroTier identity including its private key\. This file identifies the system on the network, which means you can move a ZeroTier address around by copying this file and you should back up this file if you want to save your system's static ZeroTier address\. This file must be protected, since theft of its secret key will allow anyone to impersonate your device on any network and decrypt traffic\. For network controllers this file is particularly sensitive since it constitutes the private key for a certificate authority for the controller's networks\.
-.IP \(bu 2
-\fBauthtoken\.secret\fP:
-The secret token used to authenticate requests to the service's local JSON API\. If it does not exist it is generated from a secure random source on service start\. To use, send it in the "X\-ZT1\-Auth" header with HTTP requests to 127\.0\.0\.1:<primary port>\|\.
-.IP \(bu 2
-\fBdevicemap\fP:
+.TP
+\fBauthtoken\.secret\fR
+The secret token used to authenticate requests to the service's local JSON API\. If it does not exist it is generated from a secure random source on service start\. To use, send it in the "X\-ZT1\-Auth" header with HTTP requests to 127\.0\.0\.1:\fIprimary port\fR\.
+.TP
+\fBdevicemap\fR
 Remembers mappings of zt# interface numbers to ZeroTier networks so they'll persist across restarts\. On some systems that support longer interface names that can encode the network ID (such as FreeBSD) this file may not be present\.
-.IP \(bu 2
-\fBzerotier\-one\.pid\fP:
+.TP
+\fBzerotier\-one\.pid\fR
 ZeroTier's PID\. This file is deleted on normal shutdown\.
-.IP \(bu 2
-\fBzerotier\-one\.port\fP:
-ZeroTier's primary port, which is also where its JSON API is found at 127\.0\.0\.1:<this port>\|\. This file is created on startup and is read by zerotier\-cli(1) to determine where it should find the control API\.
-.IP \(bu 2
-\fBcontroller\.db\fP:
+.TP
+\fBzerotier\-one\.port\fR
+ZeroTier's primary port, which is also where its JSON API is found at 127\.0\.0\.1:\fIthis port\fR\. This file is created on startup and is read by zerotier\-cli(1) to determine where it should find the control API\.
+.TP
+\fBcontroller\.db\fR
 If the ZeroTier One service is built with the network controller enabled, this file contains the controller's SQLite3 database\.
-.IP \(bu 2
-\fBcontroller\.db\.backup\fP:
+.TP
+\fBcontroller\.db\.backup\fR
 If the ZeroTier One service is built with the network controller enabled, it periodically backs up its controller\.db database in this file (currently every 5 minutes if there have been changes)\. Since this file is not a currently in use SQLite3 database it's safer to back up without corruption\. On new backups the file is rotated out rather than being rewritten in place\.
-.IP \(bu 2
-\fBiddb\.d/\fP (directory):
-Caches the public identity of every peer ZeroTier has spoken with in the last 60 days\. This directory and its contents can be deleted, but this may result in slower connection initations since it will require that we go out and re\-fetch full identities for peers we're speaking to\.
-.IP \(bu 2
-\fBnetworks\.d\fP (directory):
-This caches network configurations and certificate information for networks you belong to\. ZeroTier scans this directory for <network ID>\|\.conf files on startup to recall its networks, so "touch"ing an empty <network ID>\|\.conf file in this directory is a way of pre\-configuring ZeroTier to join a specific network on startup without using the API\. If the config file is empty ZeroTIer will just fetch it from the network's controller\.
-
-.RE
-.SH COPYRIGHT
-.P
+.TP
+\fBiddb\.d/\fR (directory)
+Caches the public identity of every peer ZeroTier has spoken with in the last 60 days\. This directory and its contents can be deleted, but this may result in slower connection initiations since it will require that we go out and re\-fetch full identities for peers we're speaking to\.
+.TP
+\fBnetworks\.d\fR (directory)
+This caches network configurations and certificate information for networks you belong to\. ZeroTier scans this directory for \fInetwork ID\fR\.conf files on startup to recall its networks, so "touch"ing an empty \fInetwork ID\fR\.conf file in this directory is a way of pre\-configuring ZeroTier to join a specific network on startup without using the API\. If the config file is empty ZeroTIer will just fetch it from the network's controller\.
+.SH "COPYRIGHT"
 (c)2011\-2016 ZeroTier, Inc\. \-\- https://www\.zerotier\.com/ \-\- https://github\.com/zerotier
-.SH SEE ALSO
-.P
+.SH "SEE ALSO"
 zerotier\-cli(1), zerotier\-idtool(1)
-

--- a/make-linux.mk
+++ b/make-linux.mk
@@ -397,7 +397,7 @@ override CXXFLAGS+=-fPIC -fPIE
 override LDFLAGS+=-Wl,-z,noexecstack
 
 .PHONY: all
-all:	one
+all:	one doc
 
 .PHONY: one
 one: otel zerotier-one zerotier-idtool zerotier-cli


### PR DESCRIPTION
Hello, I've noticed that there have been a [few changes](https://github.com/zerotier/ZeroTierOne/commit/1e2ff042b487adf41c6ff3eab3d3bac5cc809cdd) to the manpages Markdown, but the shipped files were never rebuilt. 

I've rebuilt them and cleaned up the build script as a treat.
The key change is that the script doesn't override PATH variable anymore, so we can test for ronn and NodeJS directly from PATH by using `type` command. This is important for systems that have non-standard build environments (e.g Nix).
I've also added `doc` target to `all` for Make, so that the manpages can be built as a part of common build process.