### PR TITLE
Fix recreating NLA profile after reconnect on Windows

### DIFF
--- a/osdep/WindowsEthernetTap.cpp
+++ b/osdep/WindowsEthernetTap.cpp
@@ -1066,10 +1066,10 @@ void WindowsEthernetTap::threadMain() throw()
 					ipnr.InterfaceLuid.Value = _deviceLuid.Value;
 					ipnr.PhysicalAddress[0] = _mac[0] ^ 0x10;	// just make something up that's consistent and not part of this net
 					ipnr.PhysicalAddress[1] = 0x00;
-					ipnr.PhysicalAddress[2] = (UCHAR)((_deviceGuid.Data1 >> 24) & 0xff);
-					ipnr.PhysicalAddress[3] = (UCHAR)((_deviceGuid.Data1 >> 16) & 0xff);
-					ipnr.PhysicalAddress[4] = (UCHAR)((_deviceGuid.Data1 >> 8) & 0xff);
-					ipnr.PhysicalAddress[5] = (UCHAR)(_deviceGuid.Data1 & 0xff);
+					ipnr.PhysicalAddress[2] = (UCHAR)((_nwid >> 24) & 0xff);
+					ipnr.PhysicalAddress[3] = (UCHAR)((_nwid >> 16) & 0xff);
+					ipnr.PhysicalAddress[4] = (UCHAR)((_nwid >> 8) & 0xff);
+					ipnr.PhysicalAddress[5] = (UCHAR)(_nwid & 0xff);
 					ipnr.PhysicalAddressLength = 6;
 					ipnr.State = NlnsPermanent;
 					ipnr.IsRouter = 1;


### PR DESCRIPTION
The fake ARP entry used to trick Windows NLA into recognizing this adapter as a real network derived its gateway MAC from the tap adapter's NetCfgInstanceId GUID. Since Disconnect then Reconnect in ZeroTier fully uninstalls and recreates the tap adapter, each reconnect produced a new random GUID and therefore a new fake gateway MAC. NLA treats this as a distinct network and ignores the previously configured network profile each time.

This change derives the fake gateway MAC from the ZeroTier network ID instead of the device GUID, so the NLA signature stays stable across tap adapter recreation as long as the network ID is unchanged.