### PR TITLE
Preserve flow ordering with Linux TAP multiqueue

### DIFF
--- a/doc/linux-tap-multiqueue.md
+++ b/doc/linux-tap-multiqueue.md
@@ -1,0 +1,41 @@
+# Linux TAP multiqueue receive path
+
+On Linux, enabling `multicoreEnabled` creates multiple TAP receive workers.
+Each worker needs its own TAP queue to preserve packet ordering within a flow.
+
+## Why separate queues are required
+
+Having several workers read a single `/dev/net/tun` descriptor lets different
+threads dequeue adjacent packets from the same FIFO. Their processing can then
+complete in a different order, which is particularly visible with sustained,
+high-rate UDP traffic.
+
+When the configured concurrency is greater than one, ZeroTier creates the TAP
+interface with `IFF_MULTI_QUEUE` and attaches one descriptor per worker. Linux
+assigns a flow to a queue, so each flow has one reader while unrelated flows
+can still be processed in parallel. Single-worker operation continues to use a
+normal, single-queue TAP interface.
+
+## Configuration
+
+The existing local configuration controls this behavior; no new setting is
+introduced:
+
+```json
+{
+  "settings": {
+    "multicoreEnabled": true,
+    "concurrency": 2,
+    "cpuPinningEnabled": false
+  }
+}
+```
+
+At startup, a multiqueue interface reports the number of configured queues:
+
+```text
+Configured 2 Linux TAP queues for ztabcdefgh
+```
+
+If an additional queue cannot be attached, interface creation fails instead
+of silently falling back to multiple readers on the shared descriptor.

--- a/osdep/LinuxEthernetTap.cpp
+++ b/osdep/LinuxEthernetTap.cpp
@@ -120,7 +120,7 @@ LinuxEthernetTap::LinuxEthernetTap(
 	, _mac(mac)
 	, _homePath(homePath)
 	, _mtu(mtu)
-	, _fd(0)
+	, _fd(-1)
 	, _enabled(true)
 	, _run(true)
 	, _lastIfAddrsUpdate(0)
@@ -138,9 +138,9 @@ LinuxEthernetTap::LinuxEthernetTap(
 	OSUtils::ztsnprintf(nwids, sizeof(nwids), "%.16llx", static_cast<unsigned long long>(nwid));
 
 	_fd = ::open("/dev/net/tun", O_RDWR);
-	if (_fd <= 0) {
+	if (_fd < 0) {
 		_fd = ::open("/dev/tun", O_RDWR);
-		if (_fd <= 0)
+		if (_fd < 0)
 			throw std::runtime_error(std::string("could not open TUN/TAP device: ") + strerror(errno));
 	}
 
@@ -206,7 +206,8 @@ LinuxEthernetTap::LinuxEthernetTap(
 #endif
 	}
 
-	ifr.ifr_flags = IFF_TAP | IFF_NO_PI;
+	const short tapFlags = IFF_TAP | IFF_NO_PI | ((concurrency > 1) ? IFF_MULTI_QUEUE : 0);
+	ifr.ifr_flags = tapFlags;
 	if (ioctl(_fd, TUNSETIFF, (void*)&ifr) < 0) {
 		::close(_fd);
 		throw std::runtime_error("unable to configure TUN/TAP device for TAP operation");
@@ -214,12 +215,55 @@ LinuxEthernetTap::LinuxEthernetTap(
 
 	::ioctl(_fd, TUNSETPERSIST, 0);	  // valgrind may generate a false alarm here
 	_dev = ifr.ifr_name;
-	::fcntl(_fd, F_SETFD, fcntl(_fd, F_GETFD) | FD_CLOEXEC);
+	_tapFds.push_back(_fd);
 
-	(void)::pipe(_shutdownSignalPipe);
+	// A shared TAP descriptor lets multiple readers dequeue packets from one
+	// FIFO, which can reorder a single high-rate flow. With Linux multiqueue,
+	// the kernel hashes each flow to a stable queue and every worker owns one
+	// descriptor. This preserves per-flow ordering while retaining parallelism.
+	for (unsigned int i = 1; i < concurrency; ++i) {
+		int queueFd = ::open("/dev/net/tun", O_RDWR);
+		if (queueFd < 0)
+			queueFd = ::open("/dev/tun", O_RDWR);
+
+		struct ifreq queueIfr;
+		memset(&queueIfr, 0, sizeof(queueIfr));
+		Utils::scopy(queueIfr.ifr_name, sizeof(queueIfr.ifr_name), _dev.c_str());
+		queueIfr.ifr_flags = tapFlags;
+		if ((queueFd < 0) || (ioctl(queueFd, TUNSETIFF, (void*)&queueIfr) < 0)) {
+			const int savedErrno = errno;
+			if (queueFd >= 0)
+				::close(queueFd);
+			for (int fd : _tapFds)
+				::close(fd);
+			_tapFds.clear();
+			_fd = -1;
+			throw std::runtime_error(std::string("unable to attach Linux multiqueue TAP descriptor: ") + strerror(savedErrno));
+		}
+
+		::ioctl(queueFd, TUNSETPERSIST, 0);
+		_tapFds.push_back(queueFd);
+	}
+
+	for (int fd : _tapFds) {
+		::fcntl(fd, F_SETFD, fcntl(fd, F_GETFD) | FD_CLOEXEC);
+		::fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) | O_NONBLOCK);
+	}
+	if (_tapFds.size() > 1)
+		fprintf(stderr, "Configured %zu Linux TAP queues for %s\n", _tapFds.size(), _dev.c_str());
+
+	if (::pipe(_shutdownSignalPipe) != 0) {
+		const int savedErrno = errno;
+		for (int fd : _tapFds)
+			::close(fd);
+		_tapFds.clear();
+		_fd = -1;
+		throw std::runtime_error(std::string("unable to create TAP shutdown pipe: ") + strerror(savedErrno));
+	}
 
 	for (unsigned int i = 0; i < concurrency; ++i) {
 		_rxThreads.push_back(std::thread([this, i, concurrency, pinning] {
+			const int tapFd = _tapFds[i];
 			if (pinning) {
 				int pinCore = i % concurrency;
 				fprintf(stderr, "Pinning tap thread %d to core %d\n", i, pinCore);
@@ -300,8 +344,6 @@ LinuxEthernetTap::LinuxEthernetTap(
 					}
 				}
 
-				fcntl(_fd, F_SETFL, O_NONBLOCK);
-
 				::close(sock);
 			}
 
@@ -311,21 +353,21 @@ LinuxEthernetTap::LinuxEthernetTap(
 
 			FD_ZERO(&readfds);
 			FD_ZERO(&nullfds);
-			nfds = (int)std::max(_shutdownSignalPipe[0], _fd) + 1;
+			nfds = (int)std::max(_shutdownSignalPipe[0], tapFd) + 1;
 
 			r = 0;
 			for (;;) {
 				FD_SET(_shutdownSignalPipe[0], &readfds);
-				FD_SET(_fd, &readfds);
+				FD_SET(tapFd, &readfds);
 				select(nfds, &readfds, &nullfds, &nullfds, (struct timeval*)0);
 
 				if (FD_ISSET(_shutdownSignalPipe[0], &readfds)) {
 					break;
 				}
-				if (FD_ISSET(_fd, &readfds)) {
+				if (FD_ISSET(tapFd, &readfds)) {
 					for (;;) {
 						// read until there are no more packets, then return to outer select() loop
-						n = (int)::read(_fd, b + r, ZT_TAP_BUF_SIZE - r);
+						n = (int)::read(tapFd, b + r, ZT_TAP_BUF_SIZE - r);
 						if (n > 0) {
 							// Some tap drivers like to send the ethernet frame and the
 							// payload in two chunks, so handle that by accumulating
@@ -359,12 +401,15 @@ LinuxEthernetTap::~LinuxEthernetTap()
 {
 	_run = false;
 	(void)::write(_shutdownSignalPipe[1], "\0", 1);
-	::close(_fd);
-	::close(_shutdownSignalPipe[0]);
-	::close(_shutdownSignalPipe[1]);
 	for (std::thread& t : _rxThreads) {
 		t.join();
 	}
+	for (int fd : _tapFds)
+		::close(fd);
+	_tapFds.clear();
+	_fd = -1;
+	::close(_shutdownSignalPipe[0]);
+	::close(_shutdownSignalPipe[1]);
 }
 
 void LinuxEthernetTap::setEnabled(bool en)

--- a/osdep/LinuxEthernetTap.hpp
+++ b/osdep/LinuxEthernetTap.hpp
@@ -67,6 +67,7 @@ class LinuxEthernetTap : public EthernetTap {
 	std::vector<MulticastGroup> _multicastGroups;
 	unsigned int _mtu;
 	int _fd;
+	std::vector<int> _tapFds;
 	int _shutdownSignalPipe[2];
 	std::atomic_bool _enabled;
 	std::atomic_bool _run;


### PR DESCRIPTION
## Summary

Use Linux TAP multiqueue when the configured receive concurrency is greater
than one. Each TAP receive worker gets its own `/dev/net/tun` descriptor instead
of having every worker read the same descriptor.

This change:

- creates the interface with `IFF_MULTI_QUEUE` for multi-worker operation;
- attaches one queue descriptor per TAP receive worker;
- keeps each descriptor nonblocking and close-on-exec;
- shuts down the workers before closing their queue descriptors;
- leaves single-worker operation unchanged; and
- documents the behavior and existing configuration controls.

## Motivation and observed failure mode

The current Linux multicore path starts several receive workers, but all of
them read one TAP descriptor. Packets are dequeued from one FIFO, then handled
by different threads. Adjacent packets from a single high-rate flow can
therefore complete processing in a different order.

This was reproducible with sustained, low-latency SRT/UDP video traffic. A
single TAP reader preserved ordering but could not drain the TAP ring quickly
enough and the interface's `tx_dropped` counter increased. Multiple readers on
the shared descriptor improved drain rate but introduced packet reordering,
which appeared to SRT as gaps and unnecessary retransmissions.

Linux multiqueue provides the intended middle ground: the kernel assigns a
flow to a queue, each queue has one reader, and unrelated flows can still be
processed in parallel. This preserves ordering within a flow without removing
multicore TAP processing.

## Implementation details

When `concurrency > 1`, the first `TUNSETIFF` uses `IFF_MULTI_QUEUE`. Additional
descriptors are opened and attached to the same interface name with the same
flags. Each receive thread selects and reads only its assigned descriptor.

If an additional queue cannot be attached, interface creation fails with the
underlying error rather than silently returning to multiple readers on a
shared FIFO. The existing `multicoreEnabled`, `concurrency`, and
`cpuPinningEnabled` settings remain the only configuration; this introduces no
new setting and makes no wire-protocol, routing, encryption, or controller
change.

## Validation

- Built successfully from the current `dev` branch with `make -j4`.
- Built and ran `zerotier-selftest`; all tests passed, including 10,000-packet
  UDP and 10 MB TCP transport tests.
- Built and deployed as a Debian package based on 1.16.2 on Ubuntu 26.04.
- Verified two TAP queue descriptors with `multicoreEnabled=true` and
  `concurrency=2`.
- During sustained approximately 70 Mb/s SRT video traffic, the ZeroTier TAP
  `tx_dropped` counter remained unchanged through the observation interval.
- Verified startup logging reports the active queue count.

## Compatibility and scope

- Linux only.
- Single-worker behavior is unchanged.
- Requires Linux TAP multiqueue support when concurrency is greater than one.
- No new user-facing configuration is required.
- No ZeroTier packet format or network interoperability changes.
