### PR TITLE
Increase physical UDP receive and send buffers

### DIFF
--- a/node/Constants.hpp
+++ b/node/Constants.hpp
@@ -741,12 +741,11 @@
 /**
  * Desired receive and send buffer sizes for physical UDP sockets.
  *
- * Receive capacity is intentionally larger to absorb bursts before ZeroTier's
- * packet-processing loop drains the socket. The send side remains at 1 MiB;
- * enlarging it would add queueing capacity without addressing receive overruns.
+ * The additional capacity absorbs short bursts before ZeroTier's receive loop
+ * or the operating system's transmit path drains the socket.
  */
 #define ZT_UDP_DESIRED_RCVBUF_SIZE 4194304
-#define ZT_UDP_DESIRED_SNDBUF_SIZE 1048576
+#define ZT_UDP_DESIRED_SNDBUF_SIZE 2097152
 
 /**
  * Desired / recommended min stack size for threads (used on some platforms to reset thread stack size)

--- a/node/Constants.hpp
+++ b/node/Constants.hpp
@@ -739,9 +739,14 @@
 #define ZT_TRUST_EXPIRATION 600000
 
 /**
- * Desired buffer size for UDP sockets (used in service and osdep but defined here)
+ * Desired receive and send buffer sizes for physical UDP sockets.
+ *
+ * Receive capacity is intentionally larger to absorb bursts before ZeroTier's
+ * packet-processing loop drains the socket. The send side remains at 1 MiB;
+ * enlarging it would add queueing capacity without addressing receive overruns.
  */
-#define ZT_UDP_DESIRED_BUF_SIZE 1048576
+#define ZT_UDP_DESIRED_RCVBUF_SIZE 4194304
+#define ZT_UDP_DESIRED_SNDBUF_SIZE 1048576
 
 /**
  * Desired / recommended min stack size for threads (used on some platforms to reset thread stack size)

--- a/osdep/Binder.hpp
+++ b/osdep/Binder.hpp
@@ -449,7 +449,11 @@ class Binder {
 				++bi;
 			}
 			if (bi == _bindingCount) {
-				udps = phy.udpBind(reinterpret_cast<const struct sockaddr*>(&(ii->first)), (void*)0, ZT_UDP_DESIRED_BUF_SIZE);
+				udps = phy.udpBind(
+					reinterpret_cast<const struct sockaddr*>(&(ii->first)),
+					(void*)0,
+					ZT_UDP_DESIRED_RCVBUF_SIZE,
+					ZT_UDP_DESIRED_SNDBUF_SIZE);
 				if (udps) {
 #ifdef __LINUX__
 					// Bind Linux sockets to their device so routes that we manage do not override physical routes (wish all platforms had this!)

--- a/osdep/Phy.hpp
+++ b/osdep/Phy.hpp
@@ -324,11 +324,12 @@ template <typename HANDLER_PTR_TYPE> class Phy {
 	 * Bind a UDP socket
 	 *
 	 * @param localAddress Local endpoint address and port
-	 * @param uptr Initial value of user pointer associated with this socket (default: NULL)
-	 * @param bufferSize Desired socket receive/send buffer size -- will set as close to this as possible (default: 0, leave alone)
+	 * @param uptr Initial value of user pointer associated with this socket
+	 * @param receiveBufferSize Desired socket receive buffer size -- will set as close to this as possible (0: leave alone)
+	 * @param sendBufferSize Desired socket send buffer size -- will set as close to this as possible (0: leave alone)
 	 * @return Socket or NULL on failure to bind
 	 */
-	inline PhySocket* udpBind(const struct sockaddr* localAddress, void* uptr = (void*)0, int bufferSize = 0)
+	inline PhySocket* udpBind(const struct sockaddr* localAddress, void* uptr, int receiveBufferSize, int sendBufferSize)
 	{
 		if (_socks.size() >= ZT_PHY_MAX_SOCKETS)
 			return (PhySocket*)0;
@@ -337,15 +338,17 @@ template <typename HANDLER_PTR_TYPE> class Phy {
 		if (! ZT_PHY_SOCKFD_VALID(s))
 			return (PhySocket*)0;
 
-		if (bufferSize > 0) {
-			int bs = bufferSize;
+		if (receiveBufferSize > 0) {
+			int bs = receiveBufferSize;
 			while (bs >= 65536) {
 				int tmpbs = bs;
 				if (setsockopt(s, SOL_SOCKET, SO_RCVBUF, (const char*)&tmpbs, sizeof(tmpbs)) == 0)
 					break;
 				bs -= 4096;
 			}
-			bs = bufferSize;
+		}
+		if (sendBufferSize > 0) {
+			int bs = sendBufferSize;
 			while (bs >= 65536) {
 				int tmpbs = bs;
 				if (setsockopt(s, SOL_SOCKET, SO_SNDBUF, (const char*)&tmpbs, sizeof(tmpbs)) == 0)
@@ -445,6 +448,16 @@ template <typename HANDLER_PTR_TYPE> class Phy {
 		memcpy(&(sws.saddr), localAddress, (localAddress->sa_family == AF_INET6) ? sizeof(struct sockaddr_in6) : sizeof(struct sockaddr_in));
 
 		return (PhySocket*)&sws;
+	}
+
+	/**
+	 * Bind a UDP socket with one shared receive/send buffer size.
+	 *
+	 * This overload preserves the original API for existing callers.
+	 */
+	inline PhySocket* udpBind(const struct sockaddr* localAddress, void* uptr = (void*)0, int bufferSize = 0)
+	{
+		return udpBind(localAddress, uptr, bufferSize, bufferSize);
 	}
 
 	/**

--- a/selftest.cpp
+++ b/selftest.cpp
@@ -1546,7 +1546,7 @@ static int testPhy()
 	testPhyInstance = new Phy<TestPhyHandlers*>(&testPhyHandlers, false, true);
 
 	std::cout << "[phy] Binding UDP listen socket to 127.0.0.1/60002... ";
-	PhySocket* udpListenSock = testPhyInstance->udpBind((const struct sockaddr*)&bindaddr);
+	PhySocket* udpListenSock = testPhyInstance->udpBind((const struct sockaddr*)&bindaddr, (void*)0, 262144, 131072);
 	if (! udpListenSock) {
 		std::cout << "FAILED." << std::endl;
 		return -1;


### PR DESCRIPTION
## Summary

- split the physical UDP socket receive and send buffer configuration
- increase the requested receive buffer from 1 MiB to 4 MiB
- increase the requested send buffer from 1 MiB to 2 MiB
- preserve the existing `Phy::udpBind()` API for callers that want one shared size
- exercise the asymmetric bind path in the existing PHY self-test

## Problem

ZeroTier currently applies the same 1 MiB request to both `SO_RCVBUF` and
`SO_SNDBUF`. On a high-throughput Linux relay carrying sustained real-time UDP
traffic, the physical ZeroTier sockets accumulated 3,205 `UdpRcvbufErrors`.
The socket drop counters reported by `ss` accounted for all 3,205 errors.

At the same time:

- `UdpSndbufErrors` remained zero
- physical-interface receive and transmit drops remained zero
- the ZeroTier interface did not report receive drops
- the Linux socket receive capacity was 2 MiB, reflecting Linux's doubled
  accounting for the 1 MiB request

This isolates the loss point to burst exhaustion of the physical UDP receive
socket rather than the NIC, route, virtual interface, or UDP send socket.

Separate high-throughput sending workloads can run at roughly twice this
relay's data rate and produce larger short spikes. Doubling the send request
provides moderate transient headroom for those bursts without matching the
larger receive allocation.

## Change

`Phy::udpBind()` now accepts independent receive and send sizes. A compatibility
overload retains the original three-argument behavior by applying a shared size
to both directions, so existing callers do not change behavior.

The production Binder requests:

- 4 MiB for `SO_RCVBUF`
- 2 MiB for `SO_SNDBUF`

The existing fallback behavior is retained: if the operating system rejects a
requested size, ZeroTier retries progressively smaller values.

## Send buffer sizing

The deployed relay did not exhibit send-buffer exhaustion, so the send increase
is not presented as a fix for its receive drops. The 2 MiB value is intended as
a balanced default for higher-rate, bursty senders: it doubles upstream's
transient headroom while remaining smaller than the receive request.

Additional send capacity only adds delay when the outbound path is backlogged.
Persistent `Send-Q` growth or `UdpSndbufErrors` still indicates an underlying
capacity or scheduling problem rather than a need for unbounded buffering.

## Impact

The change does not alter ZeroTier's wire protocol, encryption, routing, or
packet ordering. It adds burst headroom to physical UDP bindings.
Systems may cap or account for socket buffers differently; the existing
best-effort fallback remains in effect.

On Linux, the 4 MiB/2 MiB requests report as 8 MiB receive and 4 MiB send due
to kernel socket-buffer accounting. The deployed host's `net.core.rmem_max`
was already large enough to permit the request.

## Validation

- `make -j2 selftest`
- `./zerotier-selftest` (including 10,000 UDP packets)
- `make -j2`
- isolated runtime socket inspection confirmed 8 MiB receive / 4 MiB send on Linux
- a deployed 4 MiB/1 MiB build confirmed the receive behavior under sustained traffic

### Deployed monitoring

The receive-buffer change was deployed with the original 1 MiB send request and
monitored continuously for 30 minutes 2 seconds under live relay traffic. This
run validates the receive-side change and provides a stable baseline; the 2 MiB
send request was validated separately by build, self-test, and isolated runtime
socket inspection. During the deployed window, the host processed:

- 56,848,408 additional inbound UDP datagrams (about 31,500/second average)
- 55,446,839 additional outbound UDP datagrams

The following counters remained zero for the entire run:

- `UdpInErrors`
- `UdpRcvbufErrors`
- `UdpSndbufErrors`
- physical-interface receive and transmit drops
- ZeroTier-interface receive and transmit drops

The ZeroTier service remained active throughout. One downstream receiver was
rebooted during the window, changing outbound traffic volume without causing
any socket-buffer or interface drops on the relay.
