### PR TITLE
Rewrite README intro, add badges, fix broken support link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,19 @@
-# ZeroTier - Global Area Networking
+<p align="center">
+  <img src="artwork/ZeroTierIcon512x512.png" alt="ZeroTier" width="120">
+</p>
+
+<h1 align="center">ZeroTier One</h1>
+
+<p align="center"><em>Global Area Networking</em></p>
+
+<p align="center">
+  <a href="https://github.com/zerotier/ZeroTierOne/actions/workflows/build.yml"><img src="https://github.com/zerotier/ZeroTierOne/actions/workflows/build.yml/badge.svg" alt="Build"></a>
+  <a href="https://github.com/zerotier/ZeroTierOne/actions/workflows/validate.yml"><img src="https://github.com/zerotier/ZeroTierOne/actions/workflows/validate.yml/badge.svg" alt="Validate"></a>
+  <a href="https://github.com/zerotier/ZeroTierOne/releases"><img src="https://img.shields.io/github/v/release/zerotier/ZeroTierOne?label=release&color=1a3d8f" alt="Latest release"></a>
+  <a href="#license"><img src="https://img.shields.io/badge/license-MPL--2.0%20%2B%20source--available-blue" alt="License"></a>
+  <a href="https://docs.zerotier.com"><img src="https://img.shields.io/badge/docs-docs.zerotier.com-1a3d8f" alt="Documentation"></a>
+  <img src="https://img.shields.io/badge/platforms-Linux%20%7C%20macOS%20%7C%20Windows%20%7C%20BSD%20%7C%20Android%20%7C%20iOS-lightgrey" alt="Platforms">
+</p>
 
 ## Quick Links
 
@@ -8,24 +23,32 @@
 * [Downloads](https://www.zerotier.com/download/)
 * [Service API Reference](service/README.md)
 * [Network Controller](nonfree/controller/README.md)
-* [Commercial Support](https://www.zerotier.com/contact)
+* [Commercial Support](https://docs.zerotier.com/support/)
 * [License Information](#license)
 
 ## About
 
-ZeroTier is a smart programmable Ethernet switch for planet Earth. It allows all networked devices, VMs, containers, and applications to communicate as if they all reside in the same physical data center or cloud region.
+ZeroTier One is modern, identity-first software-defined networking for distributed infrastructure. It connects devices, servers, VMs, containers, and applications into one secure virtual network — no matter what sits between them — so they can communicate as if they all reside on the same physical LAN, without specialized hardware or complex VPN configuration.
 
-This is accomplished by combining a cryptographically addressed and secure peer-to-peer network (termed VL1) with an Ethernet emulation layer somewhat similar to VXLAN (termed VL2). Our VL2 Ethernet virtualization layer includes advanced enterprise SDN features like fine grained access control rules for network micro-segmentation and security monitoring.
+### How It Works
 
-All ZeroTier traffic is encrypted end-to-end using secret keys that only you control. Most traffic flows peer-to-peer, though we offer free (but slow) relaying for users who cannot establish peer-to-peer connections.
+Instead of relying on physical topology, every device joins a network using its own cryptographic identity. This is built on a secure peer-to-peer transport layer (VL1) combined with an Ethernet virtualization layer similar to VXLAN (VL2), which gives you fine-grained, capability-based access control rules for network micro-segmentation and security monitoring. Access policy is centrally defined and globally enforced, so networks stay resilient and zero-trust by default across public clouds, private data centers, on-prem environments, remote devices, and edge systems.
 
-Apps for Android and iOS are available for free in the Google Play and Apple app stores.
+### Security
+
+All ZeroTier traffic is authenticated and encrypted end-to-end using keys that only you control. Connections are established peer-to-peer whenever possible, with free (but slower) relaying available for devices that can't establish a direct path.
+
+## Platforms
+
+ZeroTier One runs on Linux, macOS, Windows, and BSD. Apps for Android and iOS are available for free in the Google Play and Apple App Store.
+
+## Building and Running
 
 For repository layout, build instructions, platform requirements, and information about running ZeroTier, see [build.md](build.md).
 
 ## License
 
-See [LICENSE-MPL.txt](LICENSE-MPL.txt) for all code in node/, osdep/. service/, and everywhere else except ext/ and nonfree/.
+See [LICENSE-MPL.txt](LICENSE-MPL.txt) for all code in node/, osdep/, service/, and everywhere else except ext/ and nonfree/.
 
 See [nonfree/LICENSE.md](nonfree/LICENSE.md) for all non-free ("source available") portions of this repository.
 


### PR DESCRIPTION
Refreshes the top-level README: updated intro copy, a header badge block, and two link/typo fixes.

## Broken link

`https://www.zerotier.com/contact` (linked as "Commercial Support") returns **404** — with and without a trailing slash, so it isn't a redirect issue. Repointed at `https://docs.zerotier.com/support/`, which is where the marketing `www.zerotier.com/support/` landing page sends people anyway. Using the trailing-slash form directly, since `docs.zerotier.com/support` 301s to it.

The other five links were verified fine: docs, corporate site, downloads, `service/README.md`, `nonfree/controller/README.md`.

## Typo

License section: `node/, osdep/. service/,` -> `node/, osdep/, service/,`

## Copy

The About section is rewritten to describe ZeroTier One as identity-first SDN for distributed infrastructure, split into **About** / **How It Works** / **Security**. The platform note and the `build.md` pointer move into their own **Platforms** and **Building and Running** sections so About isn't carrying housekeeping. `build.md` is now a real link.

## Badges

Centered header block using the existing `artwork/ZeroTierIcon512x512.png`, plus:

- `build.yml` and `validate.yml` Actions status — both passing at time of writing. These reference workflow file paths, since neither workflow declares a `name:`.
- Latest release — resolves to v1.16.2, matching `version.h`.
- License — `MPL-2.0 + source-available` rather than a plain MPL badge, since `nonfree/` isn't MPL. Links to the License section.
- Docs, and a static platforms badge (checked against the `make-*.mk` files, `windows/`, and `java/`).

Every link and badge URL in the new README was verified to return 200 and all relative paths resolve.

Deliberately left out a GitHub downloads-total badge — it reads ~230, since real distribution goes through zerotier.com, so it undersells things badly.

## Note

The Platforms section adds one sentence not in the source copy — "ZeroTier One runs on Linux, macOS, Windows, and BSD." — so the section covers desktop and not just the mobile apps. Easy to drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
